### PR TITLE
비밀번호 찾기 SMTP 이용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'net.nurigo:sdk:4.3.0'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.20'

--- a/src/main/java/luckyvicky/petharmony/controller/UserController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/UserController.java
@@ -80,4 +80,20 @@ public class UserController {
             return ResponseEntity.badRequest().body(null);
         }
     }
+
+    /**
+     * 임시 비밀번호 발송 API 엔드포인트
+     *
+     * @param findPasswordDTO
+     * @return 메시지 반환
+     */
+    @PostMapping("/api/public/send-email")
+    public ResponseEntity<String> sendingEmailToFindPassword(@RequestBody FindPasswordDTO findPasswordDTO) {
+        try {
+            String resultMsg = userService.sendingEmailToFindPassword(findPasswordDTO);
+            return ResponseEntity.ok(resultMsg);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(null);
+        }
+    }
 }

--- a/src/main/java/luckyvicky/petharmony/entity/User.java
+++ b/src/main/java/luckyvicky/petharmony/entity/User.java
@@ -50,4 +50,8 @@ public class User {
     @Column(name = "user_state", nullable = false)
     private UserState userState;                  // 회원 상태 (ACTIVE, BANNED)
 
+    // 비밀번호 변경
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/luckyvicky/petharmony/service/UserService.java
+++ b/src/main/java/luckyvicky/petharmony/service/UserService.java
@@ -12,4 +12,6 @@ public interface UserService {
     String sendingNumberToFindId(FindIdDTO findIdDTO);
     // 아이디 찾기 2 - 인증번호 확인
     FindIdResponseDTO checkNumberToFindid(FindIdDTO findIdDTO);
+    // 비밀번호 찾기 (임시 비밀번호 발송)
+    String sendingEmailToFindPassword(FindPasswordDTO findPasswordDTO);
 }

--- a/src/main/java/luckyvicky/petharmony/util/EmailUtil.java
+++ b/src/main/java/luckyvicky/petharmony/util/EmailUtil.java
@@ -1,0 +1,58 @@
+package luckyvicky.petharmony.util;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.stereotype.Component;
+
+import java.util.Properties;
+
+@Component
+public class EmailUtil {
+
+    @Value("${spring.mail.host}")
+    private String mailHost;
+
+    @Value("${spring.mail.port}")
+    private int mailPort;
+
+    @Value("${spring.mail.username}")
+    private String mailUsername;
+
+    @Value("${spring.mail.password}")
+    private String mailPassword;
+
+    private JavaMailSender mailSender;
+
+    @PostConstruct
+    private void init() {
+        this.mailSender = createMailSender();
+    }
+
+    private JavaMailSender createMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(mailHost);
+        mailSender.setPort(mailPort);
+        mailSender.setUsername(mailUsername);
+        mailSender.setPassword(mailPassword);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(mailUsername);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,11 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 coolsms.api.key=NCS6JPK1HDIR84KO
 coolsms.api.secret=GPB6RNNPELMUKE4NMDGGOERJAW8VNMSK
 petharmony.phone.number=01085453684
+
+# SMTP
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=petharmony77@gmail.com
+spring.mail.password=uvpvodrzlevytlzw
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
### 비밀번호 찾기
- PetHarmony는 사용자가 비밀번호를 잊어버렸을 때, 작성했던 이메일을 인증하면 새로운 임시 비밀번호를 보내준다.
- 새로운 비밀번호는 SMTP를 통한 이메일 발송으로 보내진다.

흐름
- 이메일 인증 > 임시 비밀번호 생성(8자리) > 임시 비밀번호 저장(User 테이블) > 임시 비밀번호 발송