### PR TITLE
신고목록과 필터링, 신고상세보기, 신고처리기능 추가

### DIFF
--- a/src/main/java/luckyvicky/petharmony/controller/BoardController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/BoardController.java
@@ -3,8 +3,6 @@ package luckyvicky.petharmony.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import luckyvicky.petharmony.dto.board.*;
-import luckyvicky.petharmony.dto.comment.CommentResponseDTO;
-import luckyvicky.petharmony.entity.board.Board;
 import luckyvicky.petharmony.service.BoardPinService;
 import luckyvicky.petharmony.service.BoardService;
 import org.springframework.data.domain.Page;
@@ -12,8 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/luckyvicky/petharmony/controller/ReportController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/ReportController.java
@@ -20,6 +20,13 @@ import java.util.Objects;
 public class ReportController {
     private final ReportService reportService;
 
+    /**
+     * 새로운 신고를 처리하는 메소드
+     *
+     * @param reportPostDTO 신고 정보가 담긴 DTO 객체.
+     * @return 신고가 성공적으로 접수되었을 경우 성공 메시지를 반환하고,
+     *         실패할 경우 에러 메시지를 반환
+     */
     @PostMapping("/post")
     public ResponseEntity<String> report(@RequestBody ReportPostDTO reportPostDTO) {
 
@@ -32,6 +39,15 @@ public class ReportController {
         }
     }
 
+    /**
+     * 필터링 및 정렬 옵션을 통해 신고 목록을 페이징 처리하여 조회
+     *
+     * @param selectionString 필터 선택 기준을 콤마로 구분한 문자열.
+     * @param sortBy 정렬 기준 (기본값은 날짜별 정렬).
+     * @param page 조회할 페이지 번호 (0부터 시작).
+     * @param size 페이지 당 레코드 수 (기본값은 8).
+     * @return 조건에 맞는 신고 목록을 Page 객체로 반환
+     */
     @GetMapping("/list")
     public Page<ReportListResponseDTO> reportList(@RequestParam(value = "selection", required = false) String selectionString,
                                                   @RequestParam(value = "sortBy", required = false, defaultValue = "date") String sortBy,
@@ -41,6 +57,13 @@ public class ReportController {
         return reportService.reportList(selectionString, sortBy, page, size);
     }
 
+    /**
+     * 특정 신고 ID에 해당하는 신고 상세 정보를 조회
+     *
+     * @param reportId 조회할 신고의 ID.
+     * @return 신고 정보를 담고 있는 ReportDetailDTO 객체를 반환하며,
+     *         신고가 존재하지 않을 경우 404 Not Found 응답을 반환
+     */
     @GetMapping("/detail/{reportId}")
     public ResponseEntity<ReportDetailDTO> reportDetail(@PathVariable Long reportId){
         ReportDetailDTO reportDetailDTO = reportService.reportDetail(reportId);
@@ -50,6 +73,15 @@ public class ReportController {
         return ResponseEntity.ok(reportDetailDTO);
     }
 
+    /**
+     * 신고 처리 상태를 업데이트
+     *
+     * @param reportId 처리할 신고의 ID.
+     * @param processing 적용할 처리 상태 (예: DELETE_POST, THREE_DAY_SUSPENSION).
+     * @return 처리 상태가 성공적으로 업데이트되면 성공 메시지를 반환하고,
+     *         신고가 존재하지 않을 경우 404 Not Found 응답을 반환
+     * @throws IOException 처리 중 오류가 발생할 경우 예외
+     */
     @PutMapping("/processing/{reportId}")
     public ResponseEntity<String> reportPrecessing(@PathVariable Long reportId,
                                                    @RequestParam String processing) throws IOException {

--- a/src/main/java/luckyvicky/petharmony/controller/ReportController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/ReportController.java
@@ -2,14 +2,15 @@ package luckyvicky.petharmony.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
 import luckyvicky.petharmony.dto.report.ReportDTO;
+import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
 import luckyvicky.petharmony.service.ReportService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Objects;
 
 @RestController
@@ -29,5 +30,14 @@ public class ReportController {
         }else {
             return ResponseEntity.badRequest().body("report failed");
         }
+    }
+
+    @GetMapping("/list")
+    public Page<ReportListResponseDTO> reportList(@RequestParam(value = "selection", required = false) String selectionString,
+                                                  @RequestParam(value = "sortBy", required = false, defaultValue = "date") String sortBy,
+                                                  @RequestParam(value = "page", defaultValue = "0") int page,
+                                                  @RequestParam(value = "size", defaultValue = "8") int size){
+
+        return reportService.reportList(selectionString, sortBy, page, size);
     }
 }

--- a/src/main/java/luckyvicky/petharmony/controller/ReportController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/ReportController.java
@@ -50,14 +50,14 @@ public class ReportController {
         return ResponseEntity.ok(reportDetailDTO);
     }
 
-    @PutMapping("/precessing/{reportId}")
+    @PutMapping("/processing/{reportId}")
     public ResponseEntity<String> reportPrecessing(@PathVariable Long reportId,
-                                                            @RequestParam String processing) throws IOException {
+                                                   @RequestParam String processing) throws IOException {
         String processingResult = reportService.reportPrecessing(reportId, processing);
         if(processingResult == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok("report processing success");
+        return ResponseEntity.ok(processingResult);
     }
 }
 

--- a/src/main/java/luckyvicky/petharmony/controller/ReportController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/ReportController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.Objects;
 
 @RestController
@@ -41,11 +42,25 @@ public class ReportController {
     }
 
     @GetMapping("/detail/{reportId}")
-    public ResponseEntity<ReportDetailDTO> reportList(@PathVariable Long reportId){
+    public ResponseEntity<ReportDetailDTO> reportDetail(@PathVariable Long reportId){
         ReportDetailDTO reportDetailDTO = reportService.reportDetail(reportId);
         if(reportDetailDTO == null) {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(reportDetailDTO);
     }
+
+    @PutMapping("/precessing/{reportId}")
+    public ResponseEntity<String> reportPrecessing(@PathVariable Long reportId,
+                                                            @RequestParam String processing) throws IOException {
+        String processingResult = reportService.reportPrecessing(reportId, processing);
+        if(processingResult == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok("report processing success");
+    }
 }
+
+
+
+

--- a/src/main/java/luckyvicky/petharmony/controller/ReportController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/ReportController.java
@@ -2,15 +2,14 @@ package luckyvicky.petharmony.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
-import luckyvicky.petharmony.dto.report.ReportDTO;
+import luckyvicky.petharmony.dto.report.ReportDetailDTO;
+import luckyvicky.petharmony.dto.report.ReportPostDTO;
 import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
 import luckyvicky.petharmony.service.ReportService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Objects;
 
 @RestController
@@ -21,9 +20,9 @@ public class ReportController {
     private final ReportService reportService;
 
     @PostMapping("/post")
-    public ResponseEntity<String> report(@RequestBody ReportDTO reportDTO) {
+    public ResponseEntity<String> report(@RequestBody ReportPostDTO reportPostDTO) {
 
-        String reportMsg = reportService.report(reportDTO);
+        String reportMsg = reportService.report(reportPostDTO);
 
         if(Objects.equals(reportMsg, "report success")) {
             return ResponseEntity.ok("report success");
@@ -39,5 +38,14 @@ public class ReportController {
                                                   @RequestParam(value = "size", defaultValue = "8") int size){
 
         return reportService.reportList(selectionString, sortBy, page, size);
+    }
+
+    @GetMapping("/detail/{reportId}")
+    public ResponseEntity<ReportDetailDTO> reportList(@PathVariable Long reportId){
+        ReportDetailDTO reportDetailDTO = reportService.reportDetail(reportId);
+        if(reportDetailDTO == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(reportDetailDTO);
     }
 }

--- a/src/main/java/luckyvicky/petharmony/dto/board/BoardDetailResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/board/BoardDetailResponseDTO.java
@@ -4,11 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import luckyvicky.petharmony.dto.comment.CommentResponseDTO;
 import luckyvicky.petharmony.entity.board.Category;
 import luckyvicky.petharmony.entity.board.Image;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/luckyvicky/petharmony/dto/board/BoardDetailResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/board/BoardDetailResponseDTO.java
@@ -34,10 +34,12 @@ public class BoardDetailResponseDTO {
     private Integer views; //조회수
 
     //이미지
+    @Builder.Default
     private List<Image> images = new ArrayList<>(); //빈리스트
 
     private Integer pinCount; //pin
 
     //좋아요 여부
+    @Builder.Default
     private Boolean pinStatus = Boolean.FALSE;
 }

--- a/src/main/java/luckyvicky/petharmony/dto/comment/CommentResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/comment/CommentResponseDTO.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @Builder
 @NoArgsConstructor

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailDTO.java
@@ -1,0 +1,35 @@
+package luckyvicky.petharmony.dto.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import luckyvicky.petharmony.entity.board.ReportProcess;
+import luckyvicky.petharmony.entity.board.ReportType;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportDetailDTO {
+    //기본정보
+    private Long reportId;
+    private LocalDate reportDate;
+    private String reporterName;
+    private ReportType reportType;
+    private ReportProcess reportProcess;
+    //신고당한 글정보
+    private String postContent;
+    private Long boardId;
+    //신고내용
+    private String reportContent;
+
+    //해당 게시물의 신고목록
+    private List<ReportDetailListDTO> reportDetailList = new ArrayList<>();
+
+
+}

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailDTO.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import luckyvicky.petharmony.entity.board.ReportProcess;
 import luckyvicky.petharmony.entity.board.ReportType;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +18,7 @@ import java.util.List;
 public class ReportDetailDTO {
     //기본정보
     private Long reportId;
-    private LocalDate reportDate;
+    private LocalDateTime reportDate;
     private String reporterName;
     private ReportType reportType;
     private ReportProcess reportProcess;

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailListDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailListDTO.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import luckyvicky.petharmony.entity.board.ReportType;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class ReportDetailListDTO {
     private Long reportId;
-    private LocalDate reportDate;
+    private LocalDateTime reportDate;
     private String reporterName;
     private ReportType reportType;
 }

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailListDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportDetailListDTO.java
@@ -1,0 +1,20 @@
+package luckyvicky.petharmony.dto.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import luckyvicky.petharmony.entity.board.ReportType;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportDetailListDTO {
+    private Long reportId;
+    private LocalDate reportDate;
+    private String reporterName;
+    private ReportType reportType;
+}

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportListResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportListResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import luckyvicky.petharmony.entity.board.ReportProcess;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -14,7 +15,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class ReportListResponseDTO {
     private Long reportId; //신고 id
-    private LocalDate reportDate; //신고 날짜
+    private LocalDateTime reportDate; //신고 날짜
     private Long postId; //게시글(댓글)id
     private Long reporterId; //신고자 아이디
     private String reporterName; //신고자 이름

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportListResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportListResponseDTO.java
@@ -1,0 +1,27 @@
+package luckyvicky.petharmony.dto.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import luckyvicky.petharmony.entity.board.ReportProcess;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportListResponseDTO {
+    private Long reportId; //신고 id
+    private LocalDate reportDate; //신고 날짜
+    private Long postId; //게시글(댓글)id
+    private Long reporterId; //신고자 아이디
+    private String reporterName; //신고자 이름
+    private Long reportedId; //피신고자 아이디
+    private String reportedName; //피신고자 이름
+    private String reportContent; //신고내용
+    private LocalDate processingDate; //처리날짜
+    private ReportProcess reportProcess;//처리상태
+    private String reportType;
+}

--- a/src/main/java/luckyvicky/petharmony/dto/report/ReportPostDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/report/ReportPostDTO.java
@@ -4,13 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import luckyvicky.petharmony.entity.board.ReportType;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ReportDTO {
+public class ReportPostDTO {
     private Long reporterId; //신고자 id
     private Long reportedId; //피신고자 id
     private String reportType; //신고유형

--- a/src/main/java/luckyvicky/petharmony/entity/User.java
+++ b/src/main/java/luckyvicky/petharmony/entity/User.java
@@ -6,6 +6,7 @@ import luckyvicky.petharmony.security.Role;
 import luckyvicky.petharmony.security.UserState;
 import org.hibernate.annotations.CreationTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -51,8 +52,23 @@ public class User {
     @Column(name = "kakao_id")
     private String kakaoId;                         // 카카오 회원 ID
 
+    @Column(name = "is_withdrawal")
+    private Boolean isWithdrawal;                 // 탈퇴 여부
+
+    @Column(name = "suspension_util")
+    private LocalDate suspensionUtil;                 // 정지 여부(정지 마지막 날짜)
+
     // 비밀번호 변경
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    // 탈퇴처리
+    public void updateIsWithdrawal(Boolean isWithdrawal) { this.isWithdrawal = isWithdrawal; }
+
+    // 정지처리(정지시킬 기간을 받아서 처리), 정지와 동시에 BANNED처리
+    public void updateSuspensionUtil(int days) {
+        this.suspensionUtil = LocalDate.now().plusDays(days);
+        this.userState = UserState.BANNED;
     }
 }

--- a/src/main/java/luckyvicky/petharmony/entity/board/Board.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Board.java
@@ -57,6 +57,14 @@ public class Board {
     @Formula("(select count(*) from board_pin bc where bc.board_id = board_id)")
     private int pinCount;
 
+    @Builder.Default
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
+
+    public void isDeleteActive() {
+        this.isDeleted = true;
+    }
+
     public void viewCount() {
         this.view++;
     }

--- a/src/main/java/luckyvicky/petharmony/entity/board/Board.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Board.java
@@ -15,7 +15,6 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Table(name = "board")
 public class Board {
     @Id

--- a/src/main/java/luckyvicky/petharmony/entity/board/BoardPin.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/BoardPin.java
@@ -9,7 +9,6 @@ import luckyvicky.petharmony.entity.User;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Table(name = "board_pin")
 public class BoardPin {
 

--- a/src/main/java/luckyvicky/petharmony/entity/board/Comment.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Comment.java
@@ -1,6 +1,5 @@
 package luckyvicky.petharmony.entity.board;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.*;
 import luckyvicky.petharmony.entity.User;
@@ -14,7 +13,6 @@ import java.time.LocalDateTime;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Table(name = "comment")
 public class Comment {
 
@@ -38,7 +36,6 @@ public class Comment {
     @JoinColumn(name = "board_id")
     private Board board;                // 게시판 테이블
 
-//    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;                  // 유저 테이블

--- a/src/main/java/luckyvicky/petharmony/entity/board/Comment.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Comment.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder(toBuilder = true)
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "comment")
@@ -39,6 +39,14 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;                  // 유저 테이블
+
+    @Builder.Default
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
+
+    public void isDeleteActive() {
+        this.isDeleted = true;
+    }
 
     public void updateContent(String newContent) {
         this.commContent = newContent;

--- a/src/main/java/luckyvicky/petharmony/entity/board/Image.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Image.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Table(name = "image")
 public class Image {
 

--- a/src/main/java/luckyvicky/petharmony/entity/board/Report.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Report.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Table(name = "report")
 public class Report {
 

--- a/src/main/java/luckyvicky/petharmony/entity/board/Report.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Report.java
@@ -24,7 +24,7 @@ public class Report {
 
     @CreationTimestamp
     @Column(name = "report_date", nullable = false)
-    private LocalDate reportDate;         // 신고날짜
+    private LocalDateTime reportDate;         // 신고날짜
 
     @Column(name = "report_type", nullable = false, updatable = false)
     @Enumerated(EnumType.STRING) // Enum을 문자열로 저장

--- a/src/main/java/luckyvicky/petharmony/repository/BoardPinRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/BoardPinRepository.java
@@ -1,12 +1,7 @@
 package luckyvicky.petharmony.repository;
 
-import luckyvicky.petharmony.entity.board.Board;
 import luckyvicky.petharmony.entity.board.BoardPin;
-import luckyvicky.petharmony.entity.board.Category;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 

--- a/src/main/java/luckyvicky/petharmony/repository/BoardRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/BoardRepository.java
@@ -5,7 +5,6 @@ import luckyvicky.petharmony.entity.board.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 

--- a/src/main/java/luckyvicky/petharmony/repository/BoardRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/BoardRepository.java
@@ -8,26 +8,28 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
+    Page<Board> findAllByIsDeletedFalse(Pageable pageable);
+
     //카테고리별 list
-    Page<Board> findByCategory(Category category, Pageable pageable);
+    Page<Board> findByCategoryAndIsDeletedFalse(Category category, Pageable pageable);
 
 
     // 검색기능(category == ALL)
     // 제목으로 검색
-    Page<Board> findByBoardTitleContainingIgnoreCase(String title, Pageable pageable);
+    Page<Board> findByBoardTitleContainingIgnoreCaseAndIsDeletedFalse(String title, Pageable pageable);
 
     // 내용으로 검색
-    Page<Board> findByBoardContentContainingIgnoreCase(String content, Pageable pageable);
+    Page<Board> findByBoardContentContainingIgnoreCaseAndIsDeletedFalse(String content, Pageable pageable);
 
     // 제목 또는 내용으로 검색
-    Page<Board> findByBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCase(
+    Page<Board> findByBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCaseAndIsDeletedFalse(
             String title, String content, Pageable pageable);
 
     // 검색기능(category != ALL)
-    Page<Board> findByCategoryAndBoardTitleContainingIgnoreCase(Category category, String keyword, Pageable pageable);
+    Page<Board> findByCategoryAndBoardTitleContainingIgnoreCaseAndIsDeletedFalse(Category category, String keyword, Pageable pageable);
 
-    Page<Board> findByCategoryAndBoardContentContainingIgnoreCase(Category category, String keyword, Pageable pageable);
+    Page<Board> findByCategoryAndBoardContentContainingIgnoreCaseAndIsDeletedFalse(Category category, String keyword, Pageable pageable);
 
-    Page<Board> findByCategoryAndBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCase(Category category, String titleKeyword, String contentKeyword, Pageable pageable);
+    Page<Board> findByCategoryAndBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCaseAndIsDeletedFalse(Category category, String titleKeyword, String contentKeyword, Pageable pageable);
 
 }

--- a/src/main/java/luckyvicky/petharmony/repository/CommentRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/CommentRepository.java
@@ -6,9 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByBoard_BoardId(Long boardId);
+    List<Comment> findByBoard_BoardIdAndIsDeletedFalse(Long boardId);
 
     void deleteByBoard_BoardId(Long boardId);
-
-    Integer countByBoard_BoardId(Long boardId);
 }

--- a/src/main/java/luckyvicky/petharmony/repository/ReportRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/ReportRepository.java
@@ -15,4 +15,8 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findByBoard_BoardIdAndReportIdNot(Long boardId, Long reportId);
 
     List<Report> findByComment_CommIdAndReportIdNot(Long commId, Long reportId);
+
+    List<Report> findByBoard_BoardId(Long boardId);
+
+    List<Report> findByComment_CommId(Long commId);
 }

--- a/src/main/java/luckyvicky/petharmony/repository/ReportRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/ReportRepository.java
@@ -1,7 +1,14 @@
 package luckyvicky.petharmony.repository;
 
 import luckyvicky.petharmony.entity.board.Report;
+import luckyvicky.petharmony.entity.board.ReportProcess;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    Page<Report> findByReportProcessingIn(List<ReportProcess> statuses, Pageable pageable);
 }

--- a/src/main/java/luckyvicky/petharmony/repository/ReportRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/ReportRepository.java
@@ -11,4 +11,8 @@ import java.util.List;
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
     Page<Report> findByReportProcessingIn(List<ReportProcess> statuses, Pageable pageable);
+
+    List<Report> findByBoard_BoardIdAndReportIdNot(Long boardId, Long reportId);
+
+    List<Report> findByComment_CommIdAndReportIdNot(Long commId, Long reportId);
 }

--- a/src/main/java/luckyvicky/petharmony/service/BoardService.java
+++ b/src/main/java/luckyvicky/petharmony/service/BoardService.java
@@ -1,7 +1,6 @@
 package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.dto.board.*;
-import luckyvicky.petharmony.entity.board.Category;
 import org.springframework.data.domain.Page;
 
 import java.io.IOException;

--- a/src/main/java/luckyvicky/petharmony/service/BoardServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/BoardServiceImpl.java
@@ -50,6 +50,7 @@ public class BoardServiceImpl implements BoardService {
                 .boardContent(boardPostDTO.getContent())
                 .category(boardPostDTO.getCategory())
                 .user(user)
+
                 .build();
         boardRepository.save(board);
 
@@ -150,9 +151,9 @@ public class BoardServiceImpl implements BoardService {
 
         // 검색 및 카테고리 필터링 적용
         if (Objects.equals(category, "ALL")) {
-            boardPage = boardRepository.findAll(pageable);
+            boardPage = boardRepository.findAllByIsDeletedFalse(pageable);
         } else {
-            boardPage = boardRepository.findByCategory(Category.valueOf(category), pageable);
+            boardPage = boardRepository.findByCategoryAndIsDeletedFalse(Category.valueOf(category), pageable);
         }
 
         return boardPage.map(this::buildBoardListResponseDTO);
@@ -178,21 +179,25 @@ public class BoardServiceImpl implements BoardService {
         // 검색 및 카테고리 필터링 적용
         if (Objects.equals(category, "ALL")) {
             if ("title".equals(searchType)) {
-                boards = boardRepository.findByBoardTitleContainingIgnoreCase(keyword, pageRequest);
+                boards = boardRepository.findByBoardTitleContainingIgnoreCaseAndIsDeletedFalse(keyword, pageRequest);
             } else if ("content".equals(searchType)) {
-                boards = boardRepository.findByBoardContentContainingIgnoreCase(keyword, pageRequest);
+                boards = boardRepository.findByBoardContentContainingIgnoreCaseAndIsDeletedFalse(keyword, pageRequest);
             } else {
-                boards = boardRepository.findByBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCase(
+                boards = boardRepository
+                        .findByBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCaseAndIsDeletedFalse(
                         keyword, keyword, pageRequest);
             }
         } else {
             Category categoryEnum = Category.valueOf(category);
             if ("title".equals(searchType)) {
-                boards = boardRepository.findByCategoryAndBoardTitleContainingIgnoreCase(categoryEnum, keyword, pageRequest);
+                boards = boardRepository
+                        .findByCategoryAndBoardTitleContainingIgnoreCaseAndIsDeletedFalse(categoryEnum, keyword, pageRequest);
             } else if ("content".equals(searchType)) {
-                boards = boardRepository.findByCategoryAndBoardContentContainingIgnoreCase(categoryEnum, keyword, pageRequest);
+                boards = boardRepository
+                        .findByCategoryAndBoardContentContainingIgnoreCaseAndIsDeletedFalse(categoryEnum, keyword, pageRequest);
             } else {
-                boards = boardRepository.findByCategoryAndBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCase(
+                boards = boardRepository
+                        .findByCategoryAndBoardTitleContainingIgnoreCaseOrBoardContentContainingIgnoreCaseAndIsDeletedFalse(
                         categoryEnum, keyword, keyword, pageRequest);
             }
         }

--- a/src/main/java/luckyvicky/petharmony/service/BoardServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/BoardServiceImpl.java
@@ -4,7 +4,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import luckyvicky.petharmony.dto.board.*;
-import luckyvicky.petharmony.dto.comment.CommentResponseDTO;
 import luckyvicky.petharmony.entity.User;
 import luckyvicky.petharmony.entity.board.*;
 import luckyvicky.petharmony.repository.*;
@@ -13,7 +12,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/luckyvicky/petharmony/service/CommentService.java
+++ b/src/main/java/luckyvicky/petharmony/service/CommentService.java
@@ -3,7 +3,6 @@ package luckyvicky.petharmony.service;
 import luckyvicky.petharmony.dto.comment.CommentPostDTO;
 import luckyvicky.petharmony.dto.comment.CommentResponseDTO;
 import luckyvicky.petharmony.dto.comment.CommentUpdateDTO;
-import luckyvicky.petharmony.entity.board.Comment;
 
 import java.util.List;
 

--- a/src/main/java/luckyvicky/petharmony/service/CommentServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/CommentServiceImpl.java
@@ -14,12 +14,9 @@ import luckyvicky.petharmony.repository.CommentRepository;
 import luckyvicky.petharmony.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/luckyvicky/petharmony/service/CommentServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/CommentServiceImpl.java
@@ -122,7 +122,7 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public List<CommentResponseDTO> listComment(Long boardId) {
 
-        List<Comment> comments = commentRepository.findByBoard_BoardId(boardId);
+        List<Comment> comments = commentRepository.findByBoard_BoardIdAndIsDeletedFalse(boardId);
 
         // Comment 객체들을 CommentResponseDTO로 변환
         return comments.stream()

--- a/src/main/java/luckyvicky/petharmony/service/ReportService.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportService.java
@@ -5,6 +5,8 @@ import luckyvicky.petharmony.dto.report.ReportPostDTO;
 import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
 import org.springframework.data.domain.Page;
 
+import java.io.IOException;
+
 public interface ReportService {
 
     //신고
@@ -15,4 +17,7 @@ public interface ReportService {
 
     //신고 상세
     ReportDetailDTO reportDetail(Long reportId);
+
+    //신고처리
+    String reportPrecessing(Long reportId, String precessing) throws IOException;
 }

--- a/src/main/java/luckyvicky/petharmony/service/ReportService.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportService.java
@@ -1,8 +1,18 @@
 package luckyvicky.petharmony.service;
 
+import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
 import luckyvicky.petharmony.dto.report.ReportDTO;
+import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
 import luckyvicky.petharmony.entity.board.Report;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public interface ReportService {
+
+    //신고
     String report(ReportDTO reportDTO);
+
+    //신고리스트
+    Page<ReportListResponseDTO> reportList(String selection, String sortBy, int page, int size);
 }

--- a/src/main/java/luckyvicky/petharmony/service/ReportService.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportService.java
@@ -1,18 +1,18 @@
 package luckyvicky.petharmony.service;
 
-import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
-import luckyvicky.petharmony.dto.report.ReportDTO;
+import luckyvicky.petharmony.dto.report.ReportDetailDTO;
+import luckyvicky.petharmony.dto.report.ReportPostDTO;
 import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
-import luckyvicky.petharmony.entity.board.Report;
 import org.springframework.data.domain.Page;
-
-import java.util.List;
 
 public interface ReportService {
 
     //신고
-    String report(ReportDTO reportDTO);
+    String report(ReportPostDTO reportPostDTO);
 
     //신고리스트
     Page<ReportListResponseDTO> reportList(String selection, String sortBy, int page, int size);
+
+    //신고 상세
+    ReportDetailDTO reportDetail(Long reportId);
 }

--- a/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
@@ -3,8 +3,9 @@ package luckyvicky.petharmony.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
-import luckyvicky.petharmony.dto.report.ReportDTO;
+import luckyvicky.petharmony.dto.report.ReportDetailDTO;
+import luckyvicky.petharmony.dto.report.ReportDetailListDTO;
+import luckyvicky.petharmony.dto.report.ReportPostDTO;
 import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
 import luckyvicky.petharmony.entity.User;
 import luckyvicky.petharmony.entity.board.*;
@@ -19,10 +20,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @Log4j2
@@ -36,34 +34,35 @@ public class ReportServiceImpl implements ReportService {
     private final CommentRepository commentRepository;
 
     /**
-     * @param reportDTO 신고내용에 관한 정보들이 담겨있는 DTO
-     * @return
+     * 신고하기
+     *
+     * @param reportPostDTO 신고내용에 관한 정보들이 담겨있는 DTO
      */
     @Override
-    public String report(ReportDTO reportDTO) {
+    public String report(ReportPostDTO reportPostDTO) {
 
         //신고자와 피신고자
-        User reporter = userRepository.findById(reportDTO.getReporterId())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지않은 신고자 ID: "+reportDTO.getReporterId()));
-        User reported = userRepository.findById(reportDTO.getReportedId())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지않은 피신고자 ID: "+reportDTO.getReportedId()));
+        User reporter = userRepository.findById(reportPostDTO.getReporterId())
+                .orElseThrow(() -> new IllegalArgumentException("유효하지않은 신고자 ID: "+ reportPostDTO.getReporterId()));
+        User reported = userRepository.findById(reportPostDTO.getReportedId())
+                .orElseThrow(() -> new IllegalArgumentException("유효하지않은 피신고자 ID: "+ reportPostDTO.getReportedId()));
         Board board = null;
         Comment comment = null;
 
         // 신고당한게 댓글인지 게시물인지
-        if(reportDTO.getReportBoardOrComment().equals("board")){
-            board = boardRepository.findById(reportDTO.getReportPostId())
-                    .orElseThrow(() -> new IllegalArgumentException("유효하지않은 board ID: "+reportDTO.getReportPostId()));
+        if(reportPostDTO.getReportBoardOrComment().equals("board")){
+            board = boardRepository.findById(reportPostDTO.getReportPostId())
+                    .orElseThrow(() -> new IllegalArgumentException("유효하지않은 board ID: "+ reportPostDTO.getReportPostId()));
         }else {
-            comment = commentRepository.findById(reportDTO.getReportPostId())
-                    .orElseThrow(() -> new IllegalArgumentException("유효하지않은 comment ID: "+reportDTO.getReportPostId()));
+            comment = commentRepository.findById(reportPostDTO.getReportPostId())
+                    .orElseThrow(() -> new IllegalArgumentException("유효하지않은 comment ID: "+ reportPostDTO.getReportPostId()));
         }
 
         Report report = Report.builder()
                 .reporter(reporter)
                 .reported(reported)
-                .reportType(ReportType.valueOf(reportDTO.getReportType()))
-                .reportContent(reportDTO.getReportContent())
+                .reportType(ReportType.valueOf(reportPostDTO.getReportType()))
+                .reportContent(reportPostDTO.getReportContent())
                 .board(board)
                 .comment(comment)
                 .reportProcessing(ReportProcess.UNPROCESSED)
@@ -73,6 +72,8 @@ public class ReportServiceImpl implements ReportService {
     }
 
     /**
+     * 신고목록
+     *
      * @param selectionString 선택된 값 리스트(미처리, 보류, 처리완료)
      * @param sortBy 정렬
      * @param page 요청 페이지
@@ -120,6 +121,59 @@ public class ReportServiceImpl implements ReportService {
         return reportPage.map(this::buildReportListResponseDTO);
     }
 
+    /**
+     * 신고상세
+     *
+     * @param reportId 신고번호
+     * @return 신고번호에 대한 정보들
+     */
+    @Override
+    public ReportDetailDTO reportDetail(Long reportId) {
+
+        // 요청받은 reportId에 해당하는 Report객체
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지않은 reportID"+reportId));
+
+        //해당 신고를 제외한 신고목록
+        List<Report> otherReports = new ArrayList<>();
+        if(report.getBoard()!=null){
+            otherReports = reportRepository.findByBoard_BoardIdAndReportIdNot(report.getBoard().getBoardId(), reportId);
+        }else {
+            otherReports = reportRepository.findByComment_CommIdAndReportIdNot(report.getComment().getCommId(), reportId);
+        }
+
+        // 신고목록을 DTO 객체 리스트로 변환
+        List<ReportDetailListDTO> reportDetailListDTOS =
+                otherReports.stream().map(this::buildReportDetailListDTO).toList();
+
+        // ReportDetailDTO 변환해서 리턴
+        return ReportDetailDTO.builder()
+                .reportId(reportId)
+                .reportDate(report.getReportDate())
+                .reporterName(report.getReporter().getUserName())
+                .reportType(report.getReportType())
+                .reportProcess(report.getReportProcessing())
+                .postContent(report.getBoard()!=null?
+                        report.getBoard().getBoardContent():
+                        report.getComment().getCommContent())
+                .boardId(report.getBoard()!=null?
+                        report.getBoard().getBoardId():
+                        report.getComment().getBoard().getBoardId())
+                .reportContent(report.getReportContent())
+                .reportDetailList(reportDetailListDTOS)
+                .build();
+    }
+
+    private ReportDetailListDTO buildReportDetailListDTO(Report report) {
+        return ReportDetailListDTO.builder()
+                .reportId(report.getReportId())
+                .reportDate(report.getReportDate())
+                .reporterName(report.getReporter().getUserName())
+                .reportType(report.getReportType())
+                .build();
+    }
+
+    //report -> ReportListResponseDTO
     private ReportListResponseDTO buildReportListResponseDTO(Report report) {
 
         return ReportListResponseDTO.builder()

--- a/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
@@ -196,6 +196,8 @@ public class ReportServiceImpl implements ReportService {
             //TODO: 3일정지
         }else if(Objects.equals(processing, "ACCOUNT_TERMINATION")){
             //TODO: 회원탈퇴
+        }else if(Objects.equals(processing, "UNPROCESSED")){
+            return processing;
         }
 
         //해당 신고를 제외한 신고목록
@@ -215,7 +217,7 @@ public class ReportServiceImpl implements ReportService {
 
         // 변경된 객체들을 저장
         reportRepository.saveAll(updatedReports);
-        return "report precessing success";
+        return processing;
     }
 
     //report -> ReportDetailListDTO

--- a/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
@@ -36,12 +36,12 @@ public class ReportServiceImpl implements ReportService {
     private final UserRepository userRepository;
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
-    private final ImageService imageService;
 
     /**
      * 신고하기
      *
      * @param reportPostDTO 신고내용에 관한 정보들이 담겨있는 DTO
+     * @return 신고 성공 여부를 반환하는 문자열 ("report success" 또는 "report failed")
      */
     @Override
     public String report(ReportPostDTO reportPostDTO) {
@@ -83,6 +83,7 @@ public class ReportServiceImpl implements ReportService {
      * @param sortBy 정렬
      * @param page 요청 페이지
      * @param size 페이지 사이즈
+     * @return 선택된 필터와 정렬 기준에 따라 페이징된 신고 목록을 반환
      */
     @Override
     public Page<ReportListResponseDTO> reportList(String selectionString, String sortBy, int page, int size) {
@@ -105,7 +106,6 @@ public class ReportServiceImpl implements ReportService {
             reportPage = reportRepository.findAll(pageable);
         } else {
             List<ReportProcess> statuses = new ArrayList<>();
-            boolean includeCompleted = false;
 
             for (String status : selection) {
                 if ("UNPROCESSED".equals(status)) {
@@ -129,8 +129,8 @@ public class ReportServiceImpl implements ReportService {
     /**
      * 신고상세
      *
-     * @param reportId 신고번호
-     * @return 신고번호에 대한 정보들
+     * @param reportId reportId 조회할 신고 ID
+     * @return 신고 상세 정보 DTO
      */
     @Override
     public ReportDetailDTO reportDetail(Long reportId) {
@@ -173,7 +173,8 @@ public class ReportServiceImpl implements ReportService {
      * 신고처리
      *
      * @param reportId 처리할 reportId
-     * @return 처리여부
+     * @param processing 처리할 상태 (예: 삭제, 3일 정지, 회원 탈퇴 등)
+     * @return 처리 결과 메시지 (처리 상태)
      */
     @Override
     public String reportPrecessing(Long reportId, String processing) throws IOException {

--- a/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/ReportServiceImpl.java
@@ -3,14 +3,26 @@ package luckyvicky.petharmony.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
 import luckyvicky.petharmony.dto.report.ReportDTO;
+import luckyvicky.petharmony.dto.report.ReportListResponseDTO;
 import luckyvicky.petharmony.entity.User;
 import luckyvicky.petharmony.entity.board.*;
 import luckyvicky.petharmony.repository.BoardRepository;
 import luckyvicky.petharmony.repository.CommentRepository;
 import luckyvicky.petharmony.repository.ReportRepository;
 import luckyvicky.petharmony.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @Log4j2
@@ -59,4 +71,72 @@ public class ReportServiceImpl implements ReportService {
         reportRepository.save(report);
         return "report success";
     }
+
+    /**
+     * @param selectionString 선택된 값 리스트(미처리, 보류, 처리완료)
+     * @param sortBy 정렬
+     * @param page 요청 페이지
+     * @param size 페이지 사이즈
+     */
+    @Override
+    public Page<ReportListResponseDTO> reportList(String selectionString, String sortBy, int page, int size) {
+
+        //클라이언트에서 문자열로 받은 처리필터를 리스트로 변환
+        String[] selection = selectionString.split(",");
+
+        Sort sort;
+        if ("dateReverse".equalsIgnoreCase(sortBy)) {
+            sort = Sort.by(Sort.Direction.ASC, "reportDate"); //오래된순
+        } else {
+            sort = Sort.by(Sort.Direction.DESC, "reportDate"); // 기본 정렬: 최신순
+        }
+
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<Report> reportPage;
+
+        // select 에서 선택한 값만 보이게
+        if (selectionString.isEmpty()) {
+            reportPage = reportRepository.findAll(pageable);
+        } else {
+            List<ReportProcess> statuses = new ArrayList<>();
+            boolean includeCompleted = false;
+
+            for (String status : selection) {
+                if ("UNPROCESSED".equals(status)) {
+                    statuses.add(ReportProcess.UNPROCESSED);
+                } else if ("PENDING".equals(status)) {
+                    statuses.add(ReportProcess.PENDING);
+                } else if ("COMPLETED".equals(status)) {
+                    // 처리완료된 상태들
+                    statuses.add(ReportProcess.THREE_DAY_SUSPENSION);
+                    statuses.add(ReportProcess.DELETE_POST);
+                    statuses.add(ReportProcess.ACCOUNT_TERMINATION);
+                    statuses.add(ReportProcess.IGNORE_REPORT);
+                }
+            }
+            reportPage = reportRepository.findByReportProcessingIn(statuses, pageable);
+        }
+
+        return reportPage.map(this::buildReportListResponseDTO);
+    }
+
+    private ReportListResponseDTO buildReportListResponseDTO(Report report) {
+
+        return ReportListResponseDTO.builder()
+                .reportId(report.getReportId())
+                .reportDate(report.getReportDate())
+                .postId(report.getBoard()!=null?
+                        report.getBoard().getBoardId():
+                        report.getComment().getCommId())
+                .reporterId(report.getReporter().getUserId())
+                .reporterName(report.getReporter().getUserName())
+                .reportedId(report.getReported().getUserId())
+                .reportedName(report.getReported().getUserName())
+                .reportContent(report.getReportContent())
+                .processingDate(report.getProcessingDate())
+                .reportProcess(report.getReportProcessing())
+                .reportType(String.valueOf(report.getReportType()))
+                .build();
+    }
+
 }

--- a/src/main/java/luckyvicky/petharmony/service/S3Service.java
+++ b/src/main/java/luckyvicky/petharmony/service/S3Service.java
@@ -1,11 +1,5 @@
 package luckyvicky.petharmony.service;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;


### PR DESCRIPTION
##신고목록과 필터링, 신고상세보기, 신고처리기능 추가

- 신고 목록 및 필터링 기능 추가: 신고 리스트 조회 및 필터링/정렬 기능 구현
- 신고 상세 조회 및 관련 목록 기능 추가: 신고 상세 정보 조회 및 관련된 다른 신고 목록 조회 가능
- 논리적 삭제 도입: 게시물 및 댓글 삭제 시 실제로 삭제하지 않고 isDeleted 필드를 통해 관리
- 신고처리 중 신고당한 해당 글 삭제 기능 추가(정지, 강제탈퇴는 구현중)
- User테이블에 탈퇴여부, 정지여부를 판단하는 필드 추가(is_withdrawal, suspension_util)
- 코드 정리 및 최적화: 불필요한 코드 제거, 일부 엔티티에 기본값 설정