### PR TITLE
chore: 조회수 증가 시 업데이트시간이 변경되지 않도록 수정

### DIFF
--- a/src/main/java/luckyvicky/petharmony/entity/board/Board.java
+++ b/src/main/java/luckyvicky/petharmony/entity/board/Board.java
@@ -36,7 +36,7 @@ public class Board {
     @Column(name = "board_create", nullable = false, updatable = false)
     private LocalDateTime boardCreate;   // 게시물 생성 날짜
 
-    @UpdateTimestamp
+    @CreationTimestamp
     @Column(name = "board_update", nullable = false)
     private LocalDateTime boardUpdate;   // 게시물 업데이트 날짜
 
@@ -73,5 +73,6 @@ public class Board {
         this.boardContent = newContent;
         this.boardTitle = newTitle;
         this.category = category;
+        this.boardUpdate = LocalDateTime.now();
     }
 }


### PR DESCRIPTION
- 조회수 증가 시 'boardUpdate' 타임스탬프가 자동으로 변경되는 문제 해결
- 게시물 수정시에만 'boardUpdate'가 갱신되도록 수정