### PR TITLE
feat: 유저 BANNED 해제 기능 추가

### DIFF
--- a/src/main/java/luckyvicky/petharmony/PetharmonyApplication.java
+++ b/src/main/java/luckyvicky/petharmony/PetharmonyApplication.java
@@ -2,8 +2,10 @@ package luckyvicky.petharmony;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PetharmonyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/luckyvicky/petharmony/entity/User.java
+++ b/src/main/java/luckyvicky/petharmony/entity/User.java
@@ -74,6 +74,11 @@ public class User {
                 LocalDate.now().plusDays(days);
         this.userState = UserState.BANNED;
     }
+
+    // 정지처리해제
+    public void releaseBans() {
+        this.userState = UserState.ACTIVE;
+    }
   
     // [마이페이지] - 내 정보 수정(이름, 이메일, 전화번호)
     public void updateUserInfo(MyProfileRequestDTO myProfileRequestDTO) {

--- a/src/main/java/luckyvicky/petharmony/repository/UserRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/UserRepository.java
@@ -3,6 +3,8 @@ package luckyvicky.petharmony.repository;
 import luckyvicky.petharmony.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -12,4 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneAndKakaoIdIsNull(String phone);
     // 카카오 ID로 사용자 조회
     Optional<User> findByKakaoId(String kakaoId);
+
+    //오늘 날짜랑 suspensionUntil이랑 같은 유저 조회
+    List<User> findBySuspensionUntil(LocalDate today);
 }

--- a/src/main/java/luckyvicky/petharmony/service/BanReleaseService.java
+++ b/src/main/java/luckyvicky/petharmony/service/BanReleaseService.java
@@ -1,0 +1,5 @@
+package luckyvicky.petharmony.service;
+
+public interface BanReleaseService {
+    void releaseUserBans();
+}

--- a/src/main/java/luckyvicky/petharmony/service/BanReleaseServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/BanReleaseServiceImpl.java
@@ -1,0 +1,24 @@
+package luckyvicky.petharmony.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+@Transactional
+public class BanReleaseServiceImpl implements BanReleaseService {
+    private final UserService userService;
+
+    /**
+     * 매일 오후 11시59분 해당 날짜에 벤이 풀려야하는 유저들 벤 풀어줌
+     */
+    @Override
+    @Scheduled(cron = "0 59 23 * * *")
+    public void releaseUserBans() {
+        userService.releaseBans();
+    }
+}

--- a/src/main/java/luckyvicky/petharmony/service/UserService.java
+++ b/src/main/java/luckyvicky/petharmony/service/UserService.java
@@ -18,4 +18,7 @@ public interface UserService {
     KakaoInfoDTO getUserInfoFromKakao(String accessToken);
     // 카카오 로그인 처리 메서드
     User kakaoLogin(KakaoInfoDTO kakaoInfoDTO);
+
+    //벤 풀어주는 메소드
+    void releaseBans();
 }

--- a/src/main/java/luckyvicky/petharmony/service/UserServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/UserServiceImpl.java
@@ -26,6 +26,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -315,5 +317,18 @@ public class UserServiceImpl implements UserService {
             phone = "0" + phone;
         }
         return phone;
+    }
+
+
+    /**
+     * 벤 풀어주는 기능
+     */
+    @Override
+    public void releaseBans() {
+        List<User> users = userRepository.findBySuspensionUntil(LocalDate.now());
+        log.info(users);
+        for(User user : users){
+            user.releaseBans();
+        }
     }
 }


### PR DESCRIPTION
- 정지 기간이 만료된 유저의 벤 상태를 자동으로 해제하는 스케줄링 기능 추가
- `User` 엔티티에 유저 상태를 BANNED에서 ACTIVE로 변경하는 `releaseBans` 메소드 추가
- 스케줄링 작업을 처리하기 위한 `BanReleaseService`와 `BanReleaseServiceImpl` 구현
- `UserService`에 벤 해제 기능을 위한 `releaseBans` 메소드 추가
- 애플리케이션에서 스케줄링 기능을 활성화하기 위해 `@EnableScheduling` 추가
- 오늘 날짜와 일치하는 정지 해제일을 가진 유저들을 조회하기 위한 `UserRepository` 메소드 추가