### PR TITLE
Dev map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.33'
 	implementation "org.springframework.boot:spring-boot-starter-security"
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
@@ -44,18 +43,27 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok:1.18.20'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-	// AWS S3 서비스를 사용하기 위한 라이브러리
+	// AWS S3
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.11.238'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.3'
 	implementation 'javax.activation:activation:1.1.1'
 
-	// OpenAi키를 활용하기 위한 dotenv
+	// dotenv for OpenAI key
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
-	// test단위 테스트
-	implementation 'org.mockito:mockito-core:5.7.0'
+	// Mockito
+	testImplementation 'org.mockito:mockito-core:5.7.0'
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
+
+	// 추가된 Spring Security Test
+	testImplementation "org.springframework.security:spring-security-test:$springSecurityVersion"
 }
+
+tasks.named('test') {
+	useJUnitPlatform()
+}
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/luckyvicky/petharmony/entity/ShelterInfo.java
+++ b/src/main/java/luckyvicky/petharmony/entity/ShelterInfo.java
@@ -8,6 +8,7 @@ import java.util.Date;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,78 +20,87 @@ public class ShelterInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(length = 255)
-    private String care_nm;
+    @Column(name = "care_nm", length = 255)
+    private String careNm;
 
-    @Column(length = 255)
-    private String org_nm;
+    @Column(name = "org_nm", length = 255)
+    private String orgNm;
 
-    @Column(length = 255)
-    private String division_nm;
+    @Column(name = "division_nm", length = 255)
+    private String divisionNm;
 
-    @Column(length = 255)
-    private String save_trgt_animal;
+    @Column(name = "save_trgt_animal", length = 255)
+    private String saveTrgtAnimal;
 
-    @Column(length = 255)
-    private String care_addr;
+    @Column(name = "care_addr", length = 255)
+    private String careAddr;
 
-    @Column(length = 255)
-    private String jibun_addr;
+    @Column(name = "jibun_addr", length = 255)
+    private String jibunAddr;
 
-    @Column(precision = 10, scale = 7)
+    @Column(name = "lat", precision = 10, scale = 7)
     private BigDecimal lat;
 
-    @Column(precision = 10, scale = 7)
+    @Column(name = "lng", precision = 10, scale = 7)
     private BigDecimal lng;
 
+    @Column(name = "dsignation_date")
     @Temporal(TemporalType.DATE)
-    private Date dsignation_date;
+    private Date dsignationDate;
 
-    @Column(length = 5)
-    private String week_opr_stime;
+    @Column(name = "week_opr_stime", length = 5)
+    private String weekOprStime;
 
-    @Column(length = 5)
-    private String week_opr_etime;
+    @Column(name = "week_opr_etime", length = 5)
+    private String weekOprEtime;
 
-    @Column(length = 5)
-    private String week_cell_stime;
+    @Column(name = "week_cell_stime", length = 5)
+    private String weekCellStime;
 
-    @Column(length = 5)
-    private String week_cell_etime;
+    @Column(name = "week_cell_etime", length = 5)
+    private String weekCellEtime;
 
-    @Column(length = 5)
-    private String weekend_opr_stime;
+    @Column(name = "weekend_opr_stime", length = 5)
+    private String weekendOprStime;
 
-    @Column(length = 5)
-    private String weekend_opr_etime;
+    @Column(name = "weekend_opr_etime", length = 5)
+    private String weekendOprEtime;
 
-    @Column(length = 5)
-    private String weekend_cell_stime;
+    @Column(name = "weekend_cell_stime", length = 5)
+    private String weekendCellStime;
 
-    @Column(length = 5)
-    private String weekend_cell_etime;
+    @Column(name = "weekend_cell_etime", length = 5)
+    private String weekendCellEtime;
 
-    @Column(length = 255)
-    private String close_day;
+    @Column(name = "close_day", length = 255)
+    private String closeDay;
 
-    private int vet_person_cnt;
+    @Column(name = "vet_person_cnt")
+    private int vetPersonCnt;
 
-    private int specs_person_cnt;
+    @Column(name = "specs_person_cnt")
+    private int specsPersonCnt;
 
-    private int medical_cnt;
+    @Column(name = "medical_cnt")
+    private int medicalCnt;
 
-    private int breed_cnt;
+    @Column(name = "breed_cnt")
+    private int breedCnt;
 
-    private int quarantine_cnt;
+    @Column(name = "quarantine_cnt")
+    private int quarantineCnt;
 
-    private int feed_cnt;
+    @Column(name = "feed_cnt")
+    private int feedCnt;
 
-    private int trans_car_cnt;
+    @Column(name = "trans_car_cnt")
+    private int transCarCnt;
 
-    @Column(length = 20)
-    private String care_tel;
+    @Column(name = "care_tel", length = 20)
+    private String careTel;
 
+    @Column(name = "data_std_dt")
     @Temporal(TemporalType.DATE)
-    private Date data_std_dt;
+    private Date dataStdDt;
 
 }

--- a/src/main/java/luckyvicky/petharmony/repository/ShelterInfoRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/ShelterInfoRepository.java
@@ -4,7 +4,10 @@ import luckyvicky.petharmony.entity.ShelterInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ShelterInfoRepository extends JpaRepository<ShelterInfo, Integer> {
-    // 커스텀 쿼리 메소드는 여기에 정의
+    // careNm으로 ShelterInfo 엔티티 검색하는 메서드
+    Optional<ShelterInfo> findByCareNm(String careNm);
 }

--- a/src/main/java/luckyvicky/petharmony/service/MatchingProcessService.java
+++ b/src/main/java/luckyvicky/petharmony/service/MatchingProcessService.java
@@ -1,7 +1,9 @@
 package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.entity.PetInfo;
+import luckyvicky.petharmony.entity.ShelterInfo;
 import luckyvicky.petharmony.entity.Word;
+import luckyvicky.petharmony.repository.ShelterInfoRepository;
 import luckyvicky.petharmony.repository.WordRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,10 +18,12 @@ import java.util.stream.Collectors;
 public class MatchingProcessService {
 
     private final WordRepository wordRepository;
+    private final ShelterInfoRepository shelterInfoRepository;
 
     @Autowired
-    public MatchingProcessService(WordRepository wordRepository) {
+    public MatchingProcessService(WordRepository wordRepository, ShelterInfoRepository shelterInfoRepository) {
         this.wordRepository = wordRepository;
+        this.shelterInfoRepository = shelterInfoRepository;
     }
 
     /**
@@ -46,6 +50,8 @@ public class MatchingProcessService {
         // neuter_yn 필드를 처리하여 반환
         result.put("neuter_yn", processNeuterYn(petInfo.getNeuterYn()));
 
+        // care_nm필드를 처리하여 반환
+        result.put("care_nm", processLocation(petInfo.getCareNm()));
         return result; // 최종 처리된 데이터를 Map으로 반환
     }
 
@@ -142,5 +148,17 @@ public class MatchingProcessService {
             default:
                 return "알 수 없음";
         }
+    }
+
+    /**
+     * 위치 정보 반환하는 메서드
+     * pet_info 테이블의 care_nm과 shelter_info테이블의 care_nm이 같은 shelter_info의 org_nm빈환
+     *
+     * @param careNm pet_info테이블의 care_nm 필드값
+     * @return 매칭된 shelter_info의 org_nm 값 또는 정보 없음 문자열 반환*/
+    private String processLocation(String careNm) {
+        return shelterInfoRepository.findByCareNm(careNm)
+                .map(ShelterInfo::getOrgNm)
+                .orElse("정보 없음");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,6 @@ spring.mail.password=uvpvodrzlevytlzw
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
-dotenv.filepath=C:/Users/didek/openai-chatbot
-
+#public dotenv
+spring.profiles.active=@activatedProperties@
+dotenv.filepath=fake/path/to/env

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,3 +30,4 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
 dotenv.filepath=C:/Users/didek/openai-chatbot
+

--- a/src/test/java/luckyvicky/petharmony/MatchingProcessServiceTest.java
+++ b/src/test/java/luckyvicky/petharmony/MatchingProcessServiceTest.java
@@ -1,7 +1,9 @@
 package luckyvicky.petharmony;
 
 import luckyvicky.petharmony.entity.PetInfo;
+import luckyvicky.petharmony.entity.ShelterInfo;
 import luckyvicky.petharmony.entity.Word;
+import luckyvicky.petharmony.repository.ShelterInfoRepository;
 import luckyvicky.petharmony.repository.WordRepository;
 import luckyvicky.petharmony.service.MatchingProcessService;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,18 +13,22 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MatchingProcessServiceTest {
 
     private MatchingProcessService matchingProcessService;
+    private WordRepository wordRepository;
+    private ShelterInfoRepository shelterInfoRepository;
 
     @BeforeEach
     public void setUp() {
-        // Given: Mock WordRepository is set up with expected word mappings
-        // WordRepository를 Mocking하여 예상되는 단어 매핑을 설정합니다.
-        WordRepository wordRepository = Mockito.mock(WordRepository.class);
+        // Given: Mock WordRepository and ShelterInfoRepository is set up with expected data
+        // WordRepository와 ShelterInfoRepository를 Mocking하여 예상 데이터를 설정합니다.
+        wordRepository = Mockito.mock(WordRepository.class);
+        shelterInfoRepository = Mockito.mock(ShelterInfoRepository.class);
 
         // 테스트 데이터 기반의 Word ID 매핑 설정
         List<Word> words = Arrays.asList(
@@ -34,8 +40,16 @@ public class MatchingProcessServiceTest {
         Mockito.when(wordRepository.findByWordIdIn(Arrays.asList(1L, 3L, 7L, 17L)))
                 .thenReturn(words);
 
-        // Mock된 WordRepository로 MatchingProcessService를 초기화합니다.
-        matchingProcessService = new MatchingProcessService(wordRepository);
+        // 테스트 데이터 기반의 ShelterInfo 매핑 설정
+        ShelterInfo shelterInfo = new ShelterInfo();
+        shelterInfo.setCareNm("한국동물구조관리협회");
+        shelterInfo.setOrgNm("서울특별시");
+
+        Mockito.when(shelterInfoRepository.findByCareNm("한국동물구조관리협회"))
+                .thenReturn(Optional.of(shelterInfo));
+
+        // Mock된 WordRepository와 ShelterInfoRepository로 MatchingProcessService를 초기화합니다.
+        matchingProcessService = new MatchingProcessService(wordRepository, shelterInfoRepository);
     }
 
     @Test
@@ -74,6 +88,6 @@ public class MatchingProcessServiceTest {
         assertEquals("2017년생", result.get("age"));
         assertEquals("남아", result.get("sex_cd"));
         assertEquals("중성화 완료", result.get("neuter_yn"));
+        assertEquals("서울특별시", result.get("care_nm"));
     }
 }
-

--- a/src/test/java/luckyvicky/petharmony/controller/MatchingControllerTest.java
+++ b/src/test/java/luckyvicky/petharmony/controller/MatchingControllerTest.java
@@ -1,0 +1,86 @@
+package luckyvicky.petharmony.controller;
+
+import luckyvicky.petharmony.controller.MatchingController;
+import luckyvicky.petharmony.entity.PetInfo;
+import luckyvicky.petharmony.service.MatchingProcessService;
+import luckyvicky.petharmony.service.WordMatchingService;
+import luckyvicky.petharmony.security.JwtTokenProvider;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(MatchingController.class)  // MatchingController 클래스만 로드하여 테스트
+public class MatchingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;  // MockMvc 객체를 통해 컨트롤러 테스트
+
+    @MockBean
+    private MatchingProcessService matchingProcessService;  // MatchingProcessService를 MockBean으로 주입
+
+    @MockBean
+    private WordMatchingService wordMatchingService;  // WordMatchingService를 MockBean으로 주입
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;  // JwtTokenProvider를 MockBean으로 주입하여 테스트에서 사용
+
+    @MockBean
+    private UserDetailsService userDetailsService; // UserDetailsService를 MockBean으로 주입하여 테스트에서 사용
+
+    /**
+     * 사용자 ID로 매칭된 상위 12개의 반려동물 정보를 반환하는 엔드포인트를 테스트하는 메서드
+     */
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})  // Mock된 사용자로 테스트 수행
+    void testGetTop12PetsByUserWord() throws Exception {
+        // Given: 테스트에 사용할 PetInfo 리스트를 설정
+        List<PetInfo> mockPetInfos = Arrays.asList(
+                PetInfo.builder()
+                        .desertionNo("123456789")
+                        .kindCd("[개] 포메라니안")
+                        .age("2019(년생)")
+                        .sexCd("M")
+                        .neuterYn("Y")
+                        .words("1,2,3")
+                        .careNm("서울동물보호센터")
+                        .build()
+        );
+
+        // WordMatchingService의 getTop12PetInfosByUserWord 메서드 호출 시, mockPetInfos 리스트 반환하도록 설정
+        when(wordMatchingService.getTop12PetInfosByUserWord(anyLong())).thenReturn(mockPetInfos);
+
+        // MatchingProcessService의 processPetInfo 메서드 호출 시, 결과 맵 반환하도록 설정
+        Map<String, Object> processedResult = new HashMap<>();
+        processedResult.put("words", Arrays.asList("건강한", "회복중인", "온순한"));
+        processedResult.put("kind_cd", "포메라니안");
+        processedResult.put("age", "2019년생");
+        processedResult.put("sex_cd", "남아");
+        processedResult.put("neuter_yn", "중성화 완료");
+        processedResult.put("care_nm", "서울동물보호센터");
+        when(matchingProcessService.processPetInfo(Mockito.any(PetInfo.class))).thenReturn(processedResult);
+
+        // When: 매핑된 엔드포인트를 MockMvc를 통해 호출
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/api/user/top12/{userId}", 1L))
+                .andExpect(MockMvcResultMatchers.status().isOk())  // HTTP 상태 코드가 200 OK인지 확인
+                .andExpect(jsonPath("$[0].words").isArray())  // 반환된 JSON 배열에서 'words' 필드가 배열인지 확인
+                .andExpect(jsonPath("$[0].words[0]").value("건강한"))  // 'words' 배열의 첫 번째 요소가 "건강한"인지 확인
+                .andExpect(jsonPath("$[0].kind_cd").value("포메라니안"))  // 'kind_cd' 필드의 값이 "포메라니안"인지 확인
+                .andExpect(jsonPath("$[0].age").value("2019년생"))  // 'age' 필드의 값이 "2019년생"인지 확인
+                .andExpect(jsonPath("$[0].sex_cd").value("남아"))  // 'sex_cd' 필드의 값이 "남아"인지 확인
+                .andExpect(jsonPath("$[0].neuter_yn").value("중성화 완료"))  // 'neuter_yn' 필드의 값이 "중성화 완료"인지 확인
+                .andExpect(jsonPath("$[0].care_nm").value("서울동물보호센터"));  // 'care_nm' 필드의 값이 "서울동물보호센터"인지 확인
+    }
+}

--- a/src/test/java/luckyvicky/petharmony/repository/UserWordRepositoryTest.java
+++ b/src/test/java/luckyvicky/petharmony/repository/UserWordRepositoryTest.java
@@ -1,4 +1,4 @@
-package luckyvicky.petharmony;
+package luckyvicky.petharmony.repository;
 
 import luckyvicky.petharmony.repository.UserWordRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/luckyvicky/petharmony/service/MatchingProcessServiceTest.java
+++ b/src/test/java/luckyvicky/petharmony/service/MatchingProcessServiceTest.java
@@ -1,4 +1,4 @@
-package luckyvicky.petharmony;
+package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.entity.PetInfo;
 import luckyvicky.petharmony.entity.ShelterInfo;

--- a/src/test/java/luckyvicky/petharmony/service/OpenAiServiceImplTest.java
+++ b/src/test/java/luckyvicky/petharmony/service/OpenAiServiceImplTest.java
@@ -1,4 +1,4 @@
-package luckyvicky.petharmony;
+package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.service.openapi.OpenAiServiceImpl;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/luckyvicky/petharmony/service/PetInfoServiceTest.java
+++ b/src/test/java/luckyvicky/petharmony/service/PetInfoServiceTest.java
@@ -1,4 +1,4 @@
-package luckyvicky.petharmony;
+package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.entity.PetInfo;
 import luckyvicky.petharmony.repository.PetInfoRepository;

--- a/src/test/java/luckyvicky/petharmony/service/PetInfoWordServiceTest.java
+++ b/src/test/java/luckyvicky/petharmony/service/PetInfoWordServiceTest.java
@@ -1,4 +1,4 @@
-package luckyvicky.petharmony;
+package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.entity.PetInfo;
 import luckyvicky.petharmony.repository.PetInfoRepository;

--- a/src/test/java/luckyvicky/petharmony/service/UserWordServiceTest.java
+++ b/src/test/java/luckyvicky/petharmony/service/UserWordServiceTest.java
@@ -1,4 +1,4 @@
-package luckyvicky.petharmony;
+package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.dto.UserWordDTO;
 import luckyvicky.petharmony.service.UserWordService;


### PR DESCRIPTION
processLocation 메서드 추가 및 dotenv 설정 수정

- 펫 정보에서 위치 정보 반환하는 processLocation 메서드 추가
PetInfo 객체를 처리하여 위치 정보를 반환하는 기능을 추가.  해당 기능은 ShelterInfoRepository를 통해 ShelterInfo 엔티티의 org_nm을 반환합한다.

- matchingControllerTest 테스트 구현
MatchingController의 /api/user/top12/{userId} 엔드포인트를 테스트하는 MatchingControllerTest를 추가. MockMvc를 사용하여 API 호출 테스트를 수행.

- dotenv 공통 경로 추가
로컬 환경과 팀원들의 환경을 분리하여 설정할 수 있도록 dotenv 경로를 공통 설정과 로컬 설정으로 나누어 추가. 로컬 환경에서는 application-local.properties를 활성화하여 실제 경로를 사용하고, 팀원들 환경에서는 가짜 경로를 사용하도록 설정.