### PR TITLE
회원가입 및 로그인 | 다양한 예외 처리 로직 개선

### DIFF
--- a/src/main/java/luckyvicky/petharmony/config/WebConfig.java
+++ b/src/main/java/luckyvicky/petharmony/config/WebConfig.java
@@ -10,7 +10,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000")
-//                .allowedOrigins("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/luckyvicky/petharmony/controller/UserController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     /**
      * 회원가입 API 엔드포인트
      *
-     * @param signUpDTO 회원가입 정보가 담긴 DTO
+     * @param signUpDTO 회원가입 정보를 담은 DTO
      * @return 성공 시 "PetHarmony에 오신걸 환영합니다." 메시지, 실패 시 오류 메시지
      */
     @PostMapping("/api/public/signUp")
@@ -44,8 +44,8 @@ public class UserController {
     /**
      * 로그인 API 엔드포인트
      *
-     * @param logInDTO 사용자 로그인 정보가 담긴 DTO
-     * @return 성공 시 사용자 정보와 JWT 토큰을 담은 LoginResponseDTO, 실패 시 HTTP 400 상태와 null 응답
+     * @param logInDTO 사용자 로그인 정보를 담은 DTO
+     * @return 성공 시 사용자 정보와 JWT 토큰을 포함한 LoginResponseDTO, 실패 시 오류 메시지 반환
      */
     @PostMapping("/api/public/login")
     public ResponseEntity<?> login(@RequestBody LogInDTO logInDTO) {
@@ -66,8 +66,8 @@ public class UserController {
     /**
      * 아이디 찾기 시 인증번호 전송 API 엔드포인트
      *
-     * @param findIdDTO 사용자 전화번호 정보가 담긴 DTO
-     * @return 성공 시 인증번호 전송에 대한 결과 메시지, 실패 시 HTTP 500 상태와 오류 메시지
+     * @param findIdDTO 사용자의 전화번호 정보를 담은 DTO
+     * @return 성공 시 인증번호 전송 결과 메시지, 실패 시 오류 메시지
      */
     @PostMapping("/api/public/send-certification")
     public ResponseEntity<String> sendingNumberToFindId(@RequestBody FindIdDTO findIdDTO) {
@@ -83,8 +83,8 @@ public class UserController {
     /**
      * 인증번호 확인 API 엔드포인트
      *
-     * @param findIdDTO 사용자 전화번호와 인증번호 정보가 담긴 DTO
-     * @return 성공 시 사용자 아이디(이메일)와 가입 날짜를 담은 FindIdResponseDTO, 실패 시 HTTP 400 상태와 null 응답
+     * @param findIdDTO 사용자의 전화번호와 인증번호 정보를 담은 DTO
+     * @return 성공 시 사용자 아이디(이메일)와 가입 날짜를 포함한 FindIdResponseDTO, 실패 시 오류 메시지
      */
     @PostMapping("/api/public/check-certification")
     public ResponseEntity<FindIdResponseDTO> checkingNumberToFindId(@RequestBody FindIdDTO findIdDTO) {
@@ -99,8 +99,8 @@ public class UserController {
     /**
      * 비밀번호 찾기 시 이메일 전송 API 엔드포인트
      *
-     * @param findPasswordDTO 사용자 이메일 정보가 담긴 DTO
-     * @return 성공 시 임시 비밀번호 전송에 대한 결과 메시지, 실패 시 HTTP 400 상태와 null 응답
+     * @param findPasswordDTO 사용자의 이메일 정보를 담은 DTO
+     * @return 성공 시 임시 비밀번호 전송 결과 메시지, 실패 시 오류 메시지
      */
     @PostMapping("/api/public/send-email")
     public ResponseEntity<String> sendingEmailToFindPassword(@RequestBody FindPasswordDTO findPasswordDTO) {
@@ -115,8 +115,8 @@ public class UserController {
     /**
      * 카카오 로그인 API 엔드포인트
      *
-     * @param payload 클라이언트로부터 전달받은 카카오 액세스 토큰이 담긴 맵
-     * @return JWT 토큰과 사용자 정보를 담은 KakaoLogInResponseDTO, 성공 시 HTTP 200 상태와 함께 반환
+     * @param payload 클라이언트로부터 전달받은 카카오 액세스 토큰을 포함한 맵
+     * @return 성공 시 JWT 토큰과 사용자 정보를 포함한 KakaoLogInResponseDTO, 실패 시 HTTP 500 상태 반환
      */
     @PostMapping("api/public/kakao")
     public ResponseEntity<KakaoLogInResponseDTO> kakaoLogin(@RequestBody Map<String, String> payload) {

--- a/src/main/java/luckyvicky/petharmony/controller/UserController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/UserController.java
@@ -48,12 +48,18 @@ public class UserController {
      * @return 성공 시 사용자 정보와 JWT 토큰을 담은 LoginResponseDTO, 실패 시 HTTP 400 상태와 null 응답
      */
     @PostMapping("/api/public/login")
-    public ResponseEntity<LogInResponseDTO> login(@RequestBody LogInDTO logInDTO) {
+    public ResponseEntity<?> login(@RequestBody LogInDTO logInDTO) {
         try {
             LogInResponseDTO logInResponseDTO = userService.login(logInDTO);
             return ResponseEntity.ok(logInResponseDTO);
+        } catch (IllegalArgumentException e) {
+            // 예외 메시지를 클라이언트에 그대로 반환 (존재하지 않는 계정, 비밀번호 오류 등)
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (IllegalStateException e) {
+            // 탈퇴한 계정, 정지상태인 계정, 카카오 회원인 계정
+            return ResponseEntity.badRequest().body(e.getMessage());
         } catch (Exception e) {
-            return ResponseEntity.badRequest().body(null);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 처리 중 오류가 발생했습니다.");
         }
     }
 

--- a/src/main/java/luckyvicky/petharmony/controller/UserController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/UserController.java
@@ -135,6 +135,7 @@ public class UserController {
         // 반환할 KakaoLogInResponseDTO 객체 생성
         KakaoLogInResponseDTO response = new KakaoLogInResponseDTO(
                 jwtToken,
+                user.getUserId(),
                 user.getEmail(),
                 user.getUserName(),
                 user.getRole().toString()

--- a/src/main/java/luckyvicky/petharmony/controller/UserController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/UserController.java
@@ -33,8 +33,11 @@ public class UserController {
         try {
             userService.signUp(signUpDTO);
             return ResponseEntity.ok("PetHarmony에 오신걸 환영합니다.");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
+            // 예외 메시지를 클라이언트에 그대로 반환
             return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원가입 처리 중 오류가 발생했습니다.");
         }
     }
 

--- a/src/main/java/luckyvicky/petharmony/dto/user/KakaoLogInResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/user/KakaoLogInResponseDTO.java
@@ -9,6 +9,8 @@ import lombok.*;
 public class KakaoLogInResponseDTO {
     private String jwtToken;
 
+    private Long userId;
+
     private String email;
 
     private String userName;

--- a/src/main/java/luckyvicky/petharmony/repository/UserRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/UserRepository.java
@@ -14,7 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneAndKakaoIdIsNull(String phone);
     // 카카오 ID로 사용자 조회
     Optional<User> findByKakaoId(String kakaoId);
-
+    // 탈퇴한 사용자 중 이메일로 사용자 조회
+    Optional<User> findByIsWithdrawalTrueAndEmail(String email);
     //오늘 날짜랑 suspensionUntil이랑 같은 유저 조회
     List<User> findBySuspensionUntil(LocalDate today);
 }

--- a/src/main/java/luckyvicky/petharmony/repository/UserRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/UserRepository.java
@@ -16,6 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(String kakaoId);
     // 탈퇴한 사용자 중 이메일로 사용자 조회
     Optional<User> findByIsWithdrawalTrueAndEmail(String email);
+    // 카카오 ID가 있는지 이메일로 사용자 조회
+    Optional<User> findByEmailAndKakaoIdIsNotNull(String email);
     //오늘 날짜랑 suspensionUntil이랑 같은 유저 조회
     List<User> findBySuspensionUntil(LocalDate today);
 }

--- a/src/main/java/luckyvicky/petharmony/security/CustomUserDetails.java
+++ b/src/main/java/luckyvicky/petharmony/security/CustomUserDetails.java
@@ -40,6 +40,10 @@ public class CustomUserDetails implements UserDetails {
         return user.getIsWithdrawal();
     }
 
+    public UserState getUserState() {
+        return user.getUserState();
+    }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;

--- a/src/main/java/luckyvicky/petharmony/service/UserService.java
+++ b/src/main/java/luckyvicky/petharmony/service/UserService.java
@@ -18,7 +18,6 @@ public interface UserService {
     KakaoInfoDTO getUserInfoFromKakao(String accessToken);
     // 카카오 로그인 처리 메서드
     User kakaoLogin(KakaoInfoDTO kakaoInfoDTO);
-
-    //벤 풀어주는 메소드
+    // 활동 정지 해제 메서드
     void releaseBans();
 }

--- a/src/main/java/luckyvicky/petharmony/service/UserServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/UserServiceImpl.java
@@ -57,9 +57,17 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public User signUp(SignUpDTO signUpDTO) {
-        // 이메일 중복 체크
-        if (userRepository.findByEmail(signUpDTO.getEmail()).isPresent()) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        // 탈퇴한 사용자 이메일인지 확인
+        Optional<User> withdrawanUser = userRepository.findByIsWithdrawalTrueAndEmail(signUpDTO.getEmail());
+        if (withdrawanUser.isPresent()) {
+            throw new IllegalArgumentException("🐶해당 이메일은 탈퇴한 계정입니다." +
+                    "\npetharmony77@gmail.com로 문의주세요.");
+        }
+        // 이미 사용 중인 이메일인지 확인
+        Optional<User> existingUser = userRepository.findByEmail(signUpDTO.getEmail());
+        if (existingUser.isPresent()) {
+            throw new IllegalArgumentException("🐶이미 사용 중인 이메일입니다." +
+                    "\n다른 이메일로 회원가입을 진행해주세요.");
         }
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(signUpDTO.getPassword());

--- a/src/main/java/luckyvicky/petharmony/service/UserServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/UserServiceImpl.java
@@ -326,7 +326,6 @@ public class UserServiceImpl implements UserService {
         // 카카오 ID 기반으로 DB에 사용자 있는지 확인
         Optional<User> existingUser = userRepository.findByKakaoId(kakaoInfoDTO.getId());
         if (existingUser.isPresent()) {
-            log.info("Kakao ID {}로 이미 등록된 사용자입니다. 로그인 처리를 진행합니다.", kakaoInfoDTO.getId());
             return existingUser.get();
         } else {
             User user = User.builder()


### PR DESCRIPTION
### 회원가입 및 로그인 로직에 다양한 예외 처리 로직 추가하고 개선
클라이언트에서 발생할 수 있는 예외 상황에 대해 구체적인 메시지를 반환하도록 개선
- 회원가입 (signUp)
   - 탈퇴한 사용자 이메일인지 확인 후 예외 처리 
   - 카카오 회원인지 확인 후 예외 처리
   - 이미 사용 중인 이메일인지 확인 후 예외 처리
- 로그인 (login)
   - 카카오 회원인지 확인 후 예외 처리
   - 탈퇴한 계정인지 확인 후 예외 처리
   - 활동 정지된 계정인지 확인 후 예외 처리
   - 존재하지 않는 계정 및 비밀번호 오류 시 예외처리