### PR TITLE
메인페이지 (유기동물 슬라이드)

### DIFF
--- a/src/main/java/luckyvicky/petharmony/controller/MainController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/MainController.java
@@ -3,18 +3,25 @@ package luckyvicky.petharmony.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
-import luckyvicky.petharmony.entity.board.Board;
+import luckyvicky.petharmony.dto.main.SlideResponseDTO;
 import luckyvicky.petharmony.service.MainService;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @Log4j2
 public class MainController {
     private final MainService mainService;
+
+    @GetMapping("/api/public/slides")
+    public List<SlideResponseDTO> getPublicSlides() {
+        return mainService.getSlides();
+    }
 
     @GetMapping("/api/public/boards")
     public Page<BoardListResponseDTO> getPublicBoards(@RequestParam(value = "size", defaultValue = "5") int size) {

--- a/src/main/java/luckyvicky/petharmony/dto/main/SlideResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/main/SlideResponseDTO.java
@@ -1,0 +1,19 @@
+package luckyvicky.petharmony.dto.main;
+
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SlideResponseDTO {
+    private String desertionNo;     // pet_info 테이블 id
+
+    private String popFile;         // 이미지 경로
+
+    private String noticeNo;        // 보호 지역
+
+    private String sexCd;           // 성별
+
+    private String age;             // 나이
+}

--- a/src/main/java/luckyvicky/petharmony/repository/PetInfoRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/PetInfoRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.parameters.P;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -40,4 +41,7 @@ public interface PetInfoRepository extends JpaRepository<PetInfo, String> {
     // shelter_info와 pet_info의 care_nm(위치 정보에 활용)
     @Query("SELECT p FROM PetInfo p WHERE p.careNm = :careNm")
     List<PetInfo> findAllByCareNm(@Param("careNm") String careNm);
+
+    // notice_edt가 현재 날짜를 지난 PetInfo 조회
+    List<PetInfo> findByNoticeEdtBefore(LocalDate currentDate);
 }

--- a/src/main/java/luckyvicky/petharmony/service/MainService.java
+++ b/src/main/java/luckyvicky/petharmony/service/MainService.java
@@ -1,8 +1,14 @@
 package luckyvicky.petharmony.service;
 
 import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
+import luckyvicky.petharmony.dto.main.SlideResponseDTO;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 public interface MainService {
+    // 슬라이드
+    List<SlideResponseDTO> getSlides();
+    // 오늘의 게시물
     Page<BoardListResponseDTO> getPublicBoards(int size);
 }

--- a/src/main/java/luckyvicky/petharmony/service/MainServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/MainServiceImpl.java
@@ -4,15 +4,19 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import luckyvicky.petharmony.dto.board.BoardListResponseDTO;
+import luckyvicky.petharmony.dto.main.SlideResponseDTO;
+import luckyvicky.petharmony.entity.PetInfo;
 import luckyvicky.petharmony.entity.board.Board;
 import luckyvicky.petharmony.repository.BoardRepository;
 import luckyvicky.petharmony.repository.ImageRepository;
+import luckyvicky.petharmony.repository.PetInfoRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +27,54 @@ import java.util.stream.Collectors;
 public class MainServiceImpl implements MainService {
     private final BoardRepository boardRepository;
     private final ImageRepository imageRepository;
+    private final PetInfoRepository petInfoRepository;
+
+    @Override
+    public List<SlideResponseDTO> getSlides() {
+        LocalDate currentDate = LocalDate.now();
+        List<PetInfo> listPetinfo = petInfoRepository.findByNoticeEdtBefore(currentDate);
+
+        List<SlideResponseDTO> slideResponseDTOList = listPetinfo.stream()
+                .map(petInfo -> SlideResponseDTO.builder()
+                        .desertionNo(petInfo.getDesertionNo())
+                        .popFile(petInfo.getPopfile())
+                        .noticeNo(formatNoticeNo(petInfo.getNoticeNo()))
+                        .sexCd(formatSexCd(petInfo.getSexCd()))
+                        .age(formatAge(petInfo.getAge())+"년생")
+                        .build())
+                .collect(Collectors.toList());
+        log.info(slideResponseDTOList);
+        return slideResponseDTOList;
+    }
+
+    private String formatNoticeNo(String noticeNo) {
+        // 예) 서울-종로-2024-00116 -> 서울 종로
+        String[] parts = noticeNo.split("-");
+        if (parts.length >= 2) {
+            return parts[0] + " " + parts[1];
+        }
+        return noticeNo;
+    }
+
+    private String formatSexCd(String sexCd) {
+        switch (sexCd) {
+            case "M":
+                return "남아";
+            case "F":
+                return "여아";
+            default:
+                return "성별 추정 어려움";
+        }
+    }
+
+    private String formatAge(String age) {
+        // 앞에 4글자만 가져오기
+        if (age != null && age.length() >= 4) {
+            return age.substring(0, 4);
+        } else {
+            return "";
+        }
+    }
 
     @Override
     public Page<BoardListResponseDTO> getPublicBoards(int size) {


### PR DESCRIPTION
### 메인페이지
현재 날짜를 지난 PetInfo 데이터를 조회하여 슬라이드 형태로 제공하는 기능 구현
-> 공고 날짜가 현재 날짜보다 지났을 경우, 입양 가능
- 유기동물 슬라이드
   - DTO (유기동물 유기번호, 이미지 파일, 공고번호, 성별, 출생년도)
   - 데이터 포맷팅 
      - 공고 번호 포맷팅 -> '서울-종로-2024-00116' 형식에서 '서울 종로' 로 반환
      - 성별 포맷팅 -> 'M' -> 남아, 'F' -> 여아
      - 출생년도 포맷팅 -> 앞 4자리만 가져와 "년생"
