### PR TITLE
마이페이지 (관심있는 입양 동물), 메인페이지 (유기동물 카드) 주석 해제 -> 수정

### DIFF
--- a/src/main/java/luckyvicky/petharmony/controller/MainController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/MainController.java
@@ -22,7 +22,7 @@ public class MainController {
     /**
      * 유기동물 슬라이드 목록을 가져오는 API 엔드포인트
      *
-     * @return 슬라이드에 표시될 유기동물 정보를 담은 SlideResponseDTO 리스트
+     * @return List<SlideResponseDTO> - 슬라이드에 표시될 유기동물 정보를 담은 DTO 리스트
      */
     @GetMapping("/api/public/slides")
     public List<SlideResponseDTO> getPublicSlides() {
@@ -32,7 +32,7 @@ public class MainController {
     /**
      * 유기동물 카드 목록을 가져오는 API 엔드포인트
      *
-     * @return 유기동물 카드 정보를 담은 PetCardResponseDTO 리스트
+     * @return List<PetCardResponseDTO> - 카드에 표시될 유기동물 정보를 담은 DTO 리스트
      */
     @GetMapping("/api/public/petCards")
     public List<PetCardResponseDTO> getPublicPetCards() {
@@ -43,7 +43,7 @@ public class MainController {
      * 게시판 목록을 가져오는 API 엔드포인트
      *
      * @param size 한 페이지에 표시할 게시글 수 (기본값: 5)
-     * @return 게시판 목록 정보를 담은 BoardListResponseDTO의 페이징된 결과
+     * @return Page<BoardListResponseDTO> - 게시판 목록 정보를 담은 페이징된 DTO 결과
      */
     @GetMapping("/api/public/boards")
     public Page<BoardListResponseDTO> getPublicBoards(@RequestParam(value = "size", defaultValue = "5") int size) {

--- a/src/main/java/luckyvicky/petharmony/controller/MyPageController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/MyPageController.java
@@ -16,7 +16,11 @@ import java.util.List;
 public class MyPageController {
     private final MyPageService myPageService;
 
-    // 사용자 프로필 조회 API 엔드포인트
+    /**
+     * 사용자 프로필 조회 API 엔드포인트
+     *
+     * @return ResponseEntity<MyProfileResponseDTO> - 사용자 프로필 정보를 담은 DTO
+     */
     @GetMapping("/api/user/myProfile")
     public ResponseEntity<MyProfileResponseDTO> getMyProfile() {
         try {
@@ -27,7 +31,12 @@ public class MyPageController {
         }
     }
 
-    // 사용자 프로필 수정 API 엔드포인트
+    /**
+     * 사용자 프로필 수정 API 엔드포인트
+     *
+     * @param myProfileRequestDTO 수정할 프로필 정보를 담은 요청 DTO
+     * @return ResponseEntity<MyProfileResponseDTO> - 수정된 사용자 프로필 정보를 담은 DTO
+     */
     @PutMapping("/api/user/myProfile")
     public ResponseEntity<MyProfileResponseDTO> updateMyProfile(@RequestBody MyProfileRequestDTO myProfileRequestDTO) {
         try {
@@ -38,7 +47,12 @@ public class MyPageController {
         }
     }
 
-    // 사용자 비밀번호 수정 API 엔드포인트
+    /**
+     * 사용자 비밀번호 수정 API 엔드포인트
+     *
+     * @param passwordRequestDTO 수정할 비밀번호 정보를 담은 요청 DTO
+     * @return ResponseEntity<?> - 성공 여부를 나타내는 응답
+     */
     @PutMapping("/api/user/password")
     public ResponseEntity<?> updatePassword(@RequestBody PasswordRequestDTO passwordRequestDTO) {
         try {
@@ -49,7 +63,27 @@ public class MyPageController {
         }
     }
 
-    // 사용자가 PIN한 게시물 조회 엔드포인트
+    /**
+     * 사용자가 관심있는 입양 동물 조회 API 엔드포인트
+     *
+     * @return ResponseEntity<List<MyInterestedPetDTO>> - 관심있는 입양 동물 목록을 담은 DTO 리스트
+     */
+    @GetMapping("/api/user/interestedPets")
+    public ResponseEntity<List<MyInterestedPetDTO>> getInterestedPets() {
+        try {
+            List<MyInterestedPetDTO> myInterestedPetDTO = myPageService.getMyInterestedPet();
+            return ResponseEntity.ok(myInterestedPetDTO);
+        } catch (Exception e) {
+            log.error("관심있는 입양 동물 조회 중 오류 발생", e);
+            return ResponseEntity.badRequest().body(null);
+        }
+    }
+
+    /**
+     * 사용자가 PIN한 게시물 조회 API 엔드포인트
+     *
+     * @return ResponseEntity<List<BoardListResponseDTO>> - PIN한 게시물 목록을 담은 DTO 리스트
+     */
     @GetMapping("/api/user/pinPosts")
     public ResponseEntity<List<BoardListResponseDTO>> getPinPosts() {
         try {
@@ -61,19 +95,11 @@ public class MyPageController {
         }
     }
 
-    // 사용자가 작성한 게시물 조회 엔드포인트
-    @GetMapping("/api/user/myPosts")
-    public ResponseEntity<List<BoardListResponseDTO>> getMyPosts() {
-        try {
-            List<BoardListResponseDTO> myPosts = myPageService.getMyPosts();
-            return ResponseEntity.ok(myPosts);
-        } catch (Exception e) {
-            log.error("작성한 게시물 조회 중 오류 발생", e);
-            return ResponseEntity.badRequest().body(null);
-        }
-    }
-
-    // 사용자가 작성한 댓글 조회 엔드포인트
+    /**
+     * 사용자가 작성한 댓글 조회 API 엔드포인트
+     *
+     * @return ResponseEntity<List<MyCommentsDTO>> - 작성한 댓글 목록을 담은 DTO 리스트
+     */
     @GetMapping("/api/user/myComments")
     public ResponseEntity<List<MyCommentsDTO>> getMyComments() {
         try {
@@ -85,7 +111,27 @@ public class MyPageController {
         }
     }
 
-    // 사용자가 회원 탈퇴하는 엔드포인트
+    /**
+     * 사용자가 작성한 게시물 조회 API 엔드포인트
+     *
+     * @return ResponseEntity<List<BoardListResponseDTO>> - 작성한 게시물 목록을 담은 DTO 리스트
+     */
+    @GetMapping("/api/user/myPosts")
+    public ResponseEntity<List<BoardListResponseDTO>> getMyPosts() {
+        try {
+            List<BoardListResponseDTO> myPosts = myPageService.getMyPosts();
+            return ResponseEntity.ok(myPosts);
+        } catch (Exception e) {
+            log.error("작성한 게시물 조회 중 오류 발생", e);
+            return ResponseEntity.badRequest().body(null);
+        }
+    }
+
+    /**
+     * 사용자가 회원 탈퇴하는 API 엔드포인트
+     *
+     * @return ResponseEntity<DeleteAccountResponseDTO> - 회원 탈퇴 결과를 담은 DTO
+     */
     @PutMapping("/api/user/deleteAccount")
     public ResponseEntity<DeleteAccountResponseDTO> deleteAccount() {
         try {
@@ -96,18 +142,4 @@ public class MyPageController {
             return ResponseEntity.badRequest().body(null);
         }
     }
-
-    // 사용자가 관심있는 입양 동물 조회 엔드포인트였던 것 (수정예정)
-    /*
-    @GetMapping("/api/user/interestedPets")
-    public ResponseEntity<List<MyInterestedPetDTO>> getInterestedPets() {
-        try {
-            List<MyInterestedPetDTO> myInterestedPetDTO = myPageService.getMyInterestedPet();
-            return ResponseEntity.ok(myInterestedPetDTO);
-        } catch (Exception e) {
-            log.error("관심있는 입양 동물 조회 중 오류 발생", e);
-            return ResponseEntity.badRequest().body(null);
-        }
-    }
-     */
 }

--- a/src/main/java/luckyvicky/petharmony/dto/main/PetCardResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/main/PetCardResponseDTO.java
@@ -10,21 +10,21 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PetCardResponseDTO {
-    private String desertionNo;     // pet_info 테이블 id
+    private String desertionNo;
 
-    private String popFile;         // 이미지 경로
+    private String popFile;
 
-    private List<String> words;     // 단어
+    private List<String> words;
 
-    private String kindCd;          // 종
+    private String kindCd;
 
-    private String sexCd;           // 성별
+    private String sexCd;
 
-    private String age;             // 나이
+    private String age;
 
-    private String weight;          // 몸무게
+    private String weight;
 
-    private String orgNm;           // 보호 지역
+    private String orgNm;
 
-    private String neuterYn;        // 중성화 여부
+    private String neuterYn;
 }

--- a/src/main/java/luckyvicky/petharmony/dto/main/SlideResponseDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/main/SlideResponseDTO.java
@@ -7,13 +7,13 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SlideResponseDTO {
-    private String desertionNo;     // pet_info 테이블 id
+    private String desertionNo;
 
-    private String popFile;         // 이미지 경로
+    private String popFile;
 
-    private String orgNm;           // 보호 지역
+    private String noticeNo;
 
-    private String sexCd;           // 성별
+    private String sexCd;
 
-    private String age;             // 나이
+    private String age;
 }

--- a/src/main/java/luckyvicky/petharmony/dto/mypage/MyInterestedPetDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/mypage/MyInterestedPetDTO.java
@@ -9,21 +9,21 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MyInterestedPetDTO {
-    private String desertionNo;     // pet_info 테이블 id
+    private String desertionNo;
 
-    private String popFile;         // 이미지 경로
+    private String popFile;
 
-    private List<String> words;     // 단어
+    private List<String> words;
 
-    private String kindCd;          // 종
+    private String kindCd;
 
-    private String sexCd;           // 성별
+    private String sexCd;
 
-    private String age;             // 나이
+    private String age;
 
-    private String weight;          // 몸무게
+    private String weight;
 
-    private String orgNm;           // 보호 지역
+    private String orgNm;
 
-    private String neuterYn;        // 중성화 여부
+    private String neuterYn;
 }

--- a/src/main/java/luckyvicky/petharmony/repository/PetInfoRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/PetInfoRepository.java
@@ -39,5 +39,5 @@ public interface PetInfoRepository extends JpaRepository<PetInfo, String> {
     PetInfo findPetInfoWithShelterByDesertionNo(@Param("desertionNo") String desertionNo);
 
     // 유기동물 ID로 PetInfo 조회
-//    PetInfo findByDesertionNo(String desertionNo);
+    PetInfo findByDesertionNo(String desertionNo);
 }

--- a/src/main/java/luckyvicky/petharmony/repository/PetLikeRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/PetLikeRepository.java
@@ -8,9 +8,6 @@ import java.util.Optional;
 import java.util.List;
 
 public interface PetLikeRepository extends JpaRepository<PetLike, Long> {
-    // 사용자 ID로 PetLike 조회
-//    List<PetLike> findByUser_UserId(Long userId);
-
     Optional<PetLike> findByUser_UserIdAndDesertionNo(Long user_userId, String desertionNo);
 
     // 사용자 ID와 반려동물의 desertionNo로 좋아요 기록을 조회하는 메서드

--- a/src/main/java/luckyvicky/petharmony/service/MyPageService.java
+++ b/src/main/java/luckyvicky/petharmony/service/MyPageService.java
@@ -20,6 +20,6 @@ public interface MyPageService {
     List<MyCommentsDTO> getMyComments();
     // 현재 인증된 사용자가 회원탈퇴를 하는 메서드
     DeleteAccountResponseDTO deleteMyAccount();
-    // 현재 인증된 사용자가 관심있는 입양 동물 조회하는 메서드
-//    List<MyInterestedPetDTO> getMyInterestedPet();
+    // 현재 인증된 사용자가 관심있는 입양동물 조회하는 메서드였던 것 (수정 예정)
+    List<MyInterestedPetDTO> getMyInterestedPet();
 }

--- a/src/main/java/luckyvicky/petharmony/service/MyPageServiceImpl.java
+++ b/src/main/java/luckyvicky/petharmony/service/MyPageServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -36,9 +35,17 @@ public class MyPageServiceImpl implements MyPageService {
     private final CommentRepository commentRepository;
     private final PetLikeRepository petLikeRepository;
     private final PetInfoRepository petInfoRepository;
-    private final PetInfoWordService petInfoFormatService;
+    private final PetInfoFormatService petInfoFormatService;
 
-    // 현재 인증된 사용자의 프로필 정보를 조회하는 메서드
+    /**
+     * 현재 인증된 사용자의 프로필 정보를 조회하는 메서드
+     *
+     * 이 메서드는 현재 로그인된 사용자의 이메일을 기반으로 사용자 정보를 조회하여 반환합니다.
+     * 조회된 정보는 사용자 프로필 정보로 변환되어 클라이언트에게 반환됩니다.
+     *
+     * @return MyProfileResponseDTO - 사용자 프로필 정보를 담은 DTO
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     public MyProfileResponseDTO getMyProfile() {
         // 현재 로그인된 사용자의 정보를 가져온다(이메일)
@@ -54,7 +61,16 @@ public class MyPageServiceImpl implements MyPageService {
                 .build();
     }
 
-    // 현재 인증된 사용자의 프로필 정보를 업데이트하는 메서드
+    /**
+     * 현재 인증된 사용자의 프로필 정보를 업데이트하는 메서드
+     *
+     * 이 메서드는 클라이언트로부터 전달된 프로필 정보를 사용하여 현재 사용자의 프로필을 업데이트합니다.
+     * 업데이트된 정보는 저장된 후 클라이언트에게 반환됩니다.
+     *
+     * @param myProfileRequestDTO 수정할 프로필 정보를 담은 DTO
+     * @return MyProfileResponseDTO - 수정된 사용자 프로필 정보를 담은 DTO
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     @Transactional
     public MyProfileResponseDTO updateMyProfile(MyProfileRequestDTO myProfileRequestDTO) {
@@ -74,7 +90,15 @@ public class MyPageServiceImpl implements MyPageService {
                 .build();
     }
 
-    // 현재 인증된 사용자의 비밀번호를 업데이트하는 메서드
+    /**
+     * 현재 인증된 사용자의 비밀번호를 업데이트하는 메서드
+     *
+     * 이 메서드는 클라이언트로부터 전달된 기존 비밀번호와 새로운 비밀번호를 사용하여
+     * 현재 사용자의 비밀번호를 업데이트합니다. 기존 비밀번호가 맞지 않을 경우 예외가 발생합니다.
+     *
+     * @param passwordRequestDTO 수정할 비밀번호 정보를 담은 DTO
+     * @throws IllegalArgumentException 기존 비밀번호가 맞지 않거나 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     @Transactional
     public void updatePassword(PasswordRequestDTO passwordRequestDTO) {
@@ -93,7 +117,15 @@ public class MyPageServiceImpl implements MyPageService {
         }
     }
 
-    // 현재 인증된 사용자가 PIN한 게시물들을 조회하는 메서드
+    /**
+     * 현재 인증된 사용자가 PIN한 게시물들을 조회하는 메서드
+     *
+     * 이 메서드는 현재 사용자가 PIN한 게시물들을 조회하여 리스트로 반환합니다.
+     * 게시물은 BoardListResponseDTO로 변환되어 반환됩니다.
+     *
+     * @return List<BoardListResponseDTO> - PIN한 게시물 목록을 담은 DTO 리스트
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     public List<BoardListResponseDTO> getPinPosts() {
         // 현재 로그인된 사용자의 정보를 가져온다(이메일)
@@ -113,7 +145,6 @@ public class MyPageServiceImpl implements MyPageService {
     }
     private BoardListResponseDTO buildBoardListResponseDTO(Board board) {
         boolean hasImage = imageRepository.existsByBoard_BoardId(board.getBoardId());
-
         return BoardListResponseDTO.builder()
                 .boardId(board.getBoardId())
                 .userId(board.getUser().getUserId())
@@ -128,8 +159,16 @@ public class MyPageServiceImpl implements MyPageService {
                 .build();
     }
 
-    // 현재 인증된 사용자가 작성한 게시물들을 조회하는 메서드
-    @Override
+    /**
+     * 현재 인증된 사용자가 작성한 게시물들을 조회하는 메서드
+     *
+     * 이 메서드는 현재 사용자가 작성한 게시물들을 조회하여 리스트로 반환합니다.
+     * 게시물은 BoardListResponseDTO로 변환되어 반환됩니다.
+     *
+     * @return List<BoardListResponseDTO> - 작성한 게시물 목록을 담은 DTO 리스트
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
+ @Override
     public List<BoardListResponseDTO> getMyPosts() {
         // 현재 로그인된 사용자의 정보를 가져온다(이메일)
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -146,7 +185,15 @@ public class MyPageServiceImpl implements MyPageService {
                 .collect(Collectors.toList());
     }
 
-    // 현재 인증된 사용자가 작성한 댓글들을 조회하는 메소드
+    /**
+     * 현재 인증된 사용자가 작성한 댓글들을 조회하는 메소드
+     *
+     * 이 메서드는 현재 사용자가 작성한 댓글들을 조회하여 리스트로 반환합니다.
+     * 각 댓글은 MyCommentsDTO로 변환되어 반환됩니다.
+     *
+     * @return List<MyCommentsDTO> - 작성한 댓글 목록을 담은 DTO 리스트
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     public List<MyCommentsDTO> getMyComments() {
         // 현재 로그인된 사용자의 정보를 가져온다(이메일)
@@ -176,7 +223,15 @@ public class MyPageServiceImpl implements MyPageService {
                 .collect(Collectors.toList());
     }
 
-    // 현재 인증된 사용자가 회원탈퇴를 하는 메서드
+    /**
+     * 현재 인증된 사용자가 회원 탈퇴를 하는 메서드
+     *
+     * 이 메서드는 현재 사용자의 계정을 비활성화하여 회원 탈퇴 처리를 합니다.
+     * 탈퇴된 사용자 정보는 DeleteAccountResponseDTO로 반환됩니다.
+     *
+     * @return DeleteAccountResponseDTO - 회원 탈퇴 처리된 사용자 정보를 담은 DTO
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     @Transactional
     public DeleteAccountResponseDTO deleteMyAccount() {
@@ -195,8 +250,15 @@ public class MyPageServiceImpl implements MyPageService {
                 .build();
     }
 
-    // 현재 인증된 사용자가 관심있는 입양동물 조회하는 메서드였던 것 (수정 예정)
-    /*
+    /**
+     * 현재 인증된 사용자가 회원 탈퇴를 하는 메서드
+     *
+     * 이 메서드는 현재 사용자의 계정을 비활성화하여 회원 탈퇴 처리를 합니다.
+     * 탈퇴된 사용자 정보는 DeleteAccountResponseDTO로 반환됩니다.
+     *
+     * @return DeleteAccountResponseDTO - 회원 탈퇴 처리된 사용자 정보를 담은 DTO
+     * @throws IllegalArgumentException 사용자를 찾을 수 없을 때 발생
+     */
     @Override
     public List<MyInterestedPetDTO> getMyInterestedPet() {
         // 현재 인증된 사용자의 이메일을 가져옴
@@ -204,41 +266,31 @@ public class MyPageServiceImpl implements MyPageService {
         // 이메일로 사용자 조회
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-        // 사용자 ID로 PetLike 엔티티 리스트 조회
-        List<PetLike> petLikes = petLikeRepository.findByUser_UserId(user.getUserId());
-        // 관심 있는 입양 동물이 없으면 예외 처리
+        // 사용자 ID로 PetLike 리스트 조회
+        List<PetLike> petLikes = petLikeRepository.findByUserUserId(user.getUserId());
+        // 관심있는 입양동물이 없으면 예외 처리
         if (petLikes.isEmpty()) {
-            throw new IllegalArgumentException("관심있는 입양동물이 없습니다.");
+            return Collections.emptyList();
         }
-
-        List<MyInterestedPetDTO> myInterestedPetDTOList = petLikes.stream()
-                .map(petLike -> {
-                    PetInfo petInfo = petInfoRepository.findByDesertionNo(petLike.getDesertionNo());
-                    if (petInfo == null) {
-                        throw new IllegalArgumentException("해당하는 입양동물 정보를 찾을 수 없습니다.");
-                    }
-
-                    // PetInfo 객체를 처리하여 Map으로 변환
-                    Map<String, Object> processedInfo = petInfoFormatService.processPetInfo(petInfo);
-                    if (processedInfo == null) {
-                        processedInfo = new HashMap<>();
-                    }
-
-                    return MyInterestedPetDTO.builder()
-                            .desertionNo(petInfo.getDesertionNo())
-                            .popFile(petInfo.getPopfile())
-                            .words((List<String>) processedInfo.get("words"))
-                            .kindCd((String) processedInfo.getOrDefault("kind_cd", petInfo.getKindCd()))
-                            .sexCd((String) processedInfo.getOrDefault("sex_cd", petInfo.getSexCd()))
-                            .age((String) processedInfo.getOrDefault("age", petInfo.getAge()))
-                            .weight(petInfo.getWeight())
-                            .orgNm((String) processedInfo.getOrDefault("care_nm", "Unknown"))
-                            .neuterYn((String) processedInfo.getOrDefault("neuter_yn", "Unknown"))
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        return myInterestedPetDTOList;
+        // PetLike를 순회하며 각 입양동물 정보를 조회하고 DTO로 변환
+        return petLikes.stream().map(petLike -> {
+            PetInfo petInfo = petInfoRepository.findByDesertionNo(petLike.getDesertionNo());
+            if (petInfo == null) {
+                throw new IllegalArgumentException("해당 입양동물 정보를 찾을 수 없습니다: " + petLike.getDesertionNo());
+            }
+            // PetInfo를 처리하여 필요한 정보를 추출
+            Map<String, Object> processedInfo = petInfoFormatService.processPetInfo(petInfo);
+            return MyInterestedPetDTO.builder()
+                    .desertionNo(petInfo.getDesertionNo())
+                    .popFile(petInfo.getPopfile())
+                    .words((List<String>) processedInfo.get("words"))
+                    .kindCd((String) processedInfo.get("kind_cd_detail"))
+                    .sexCd((String) processedInfo.get("sex_cd"))
+                    .age((String) processedInfo.get("age"))
+                    .weight((String) processedInfo.get("weight"))
+                    .orgNm((String) processedInfo.get("care_nm"))
+                    .neuterYn((String) processedInfo.get("neuter_yn"))
+                    .build();
+        }).collect(Collectors.toList());
     }
-     */
 }

--- a/src/main/java/luckyvicky/petharmony/service/PetInfoFormatService.java
+++ b/src/main/java/luckyvicky/petharmony/service/PetInfoFormatService.java
@@ -147,8 +147,11 @@ public class PetInfoFormatService implements PetInfoFormatter {
      * @return 처리된 age 문자열
      */
     private String processAge(String age) {
-        String numericPart = age.replaceAll("\\D", ""); // 숫자만 추출
-        return numericPart + "년생"; // 추출된 숫자에 '년생'을 추가하여 반환
+        if (age != null && age.length() >= 4) {
+            return age.substring(0, 4)+"년생";
+        } else {
+            return "정보없음";
+        }
     }
 
     /**


### PR DESCRIPTION
### 마이페이지 
사용자 ID를 통해 PetLike 리스트를 조회하고 PetInfoFormatService를 이용해
데이터를 가공한 후, 이를 MyInterestedPetDTO로 변환하여 정보를 클라이언트에게 전달
- 관심있는 입양 동물(JPA, DTO, Service, Controller)

### 무작위 샘플링
전체 리스트를 내보내는 것보다 전체 리스트를 섞고 그 중에서 특정 개수만 내보내는 것이 효율적이라고 생각합니다.
전체 리스트를 반환하는 것보다 특정 개수만 반환하면 네트워크 대역폭이 절약되고, 클라이언트 측에서도 적은 데이터를 처리하게 되어 성능이 향상됩니다.
(관심있는 입양 동물[6개], 유기동물 카드[18개])