### PR TITLE
refactor: UserWordDTO 및 관련 클래스 리팩토링

### DIFF
--- a/src/main/java/luckyvicky/petharmony/controller/UserWordController.java
+++ b/src/main/java/luckyvicky/petharmony/controller/UserWordController.java
@@ -25,7 +25,7 @@ public class UserWordController {
      * @param userWordDTOs 사용자가 선택한 단어 ID 목록과 사용자 ID를 포함하는 DTO 목록
      */
     @PostMapping("/user/words")
-    public void saveUserWords(@RequestBody List<UserWordDTO> userWordDTOs) {
+    public void saveUserWords(@RequestBody UserWordDTO userWordDTOs) {
         // UserWordService를 호출하여 사용자가 선택한 단어들을 저장
         userWordService.saveUserWords(userWordDTOs);
     }
@@ -36,7 +36,7 @@ public class UserWordController {
      * @return 사용자가 선택한 UserWordDTO 목록을 반환합니다.
      */
     @GetMapping("/user/{userId}/words")
-    public List<UserWordDTO> getUserWords(@PathVariable Long userId) {
+    public UserWordDTO getUserWords(@PathVariable Long userId) {
         // UserWordService를 호출하여 사용자가 선택한 단어 목록을 조회하고 반환합니다.
         return userWordService.getUserWords(userId);
     }

--- a/src/main/java/luckyvicky/petharmony/dto/UserWordDTO.java
+++ b/src/main/java/luckyvicky/petharmony/dto/UserWordDTO.java
@@ -1,23 +1,15 @@
 package luckyvicky.petharmony.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
+@Builder
 public class UserWordDTO {
-    private Long userWordId; // UserWord 테이블의 ID
     private Long userId;     // 사용자 ID
-    private Long wordId;     // 단어 ID
-
-    // 기본 생성자
-    public UserWordDTO() {
-    }
-
-    // 모든 필드를 포함하는 생성자
-    public UserWordDTO(Long userWordId, Long userId, Long wordId) {
-        this.userWordId = userWordId;
-        this.userId = userId;
-        this.wordId = wordId;
-    }
+    private List<Long> wordId;     // 단어 ID 리스트
 }

--- a/src/main/java/luckyvicky/petharmony/repository/UserWordRepository.java
+++ b/src/main/java/luckyvicky/petharmony/repository/UserWordRepository.java
@@ -19,4 +19,6 @@ public interface UserWordRepository extends JpaRepository<UserWord, Long> {
      */
     @Query("SELECT uw.word.wordId FROM UserWord uw WHERE uw.user.userId = :userId")
     List<Long> findWordIdsByUserId(@Param("userId") Long userId);
+
+    List<UserWord> findByUser_UserId(Long userId);
 }


### PR DESCRIPTION
- `UserWordDTO`를 단일 단어 ID 대신 단어 ID 리스트를 처리하도록 수정
- 중복을 방지하기 위해 새로운 사용자 단어를 저장하기 전에 기존의 단어를 삭제하도록 서비스 로직 수정